### PR TITLE
feat(业务场景模型映射): 实现业务场景与AI模型的映射配置功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ server
 desktop/backend-app-secure/configs/ai-configs-qudao.json
 desktop/backend-app-secure/configs/ai-configs-外发.json
 desktop/backend-app-secure/configs/config.yaml
+.DS_Store

--- a/backend-node/src/routes/index.js
+++ b/backend-node/src/routes/index.js
@@ -19,6 +19,7 @@ const videoMergeRoutes = require('./videoMerges');
 const assetRoutes = require('./assets');
 const audioRoutes = require('./audio');
 const promptOverridesRoutes = require('./promptOverrides');
+const sceneModelMapRoutes = require('./sceneModelMap');
 
 function setupRouter(cfg, db, log) {
   const r = express.Router();
@@ -28,7 +29,8 @@ function setupRouter(cfg, db, log) {
   const aiConfig = aiConfigRoutes(db, log, cfg);
   const prop = propRoutes(db, log, cfg);
   const stub = stubRoutes(db, cfg, log);
-
+  const sceneModelMap = sceneModelMapRoutes(db, log);
+  
   const uploadService = require('../services/uploadService');
   const charLibrary = characterLibraryRoutes(db, cfg, log);
   const sceneLibrary = sceneLibraryRoutes(db, cfg, log);
@@ -286,6 +288,13 @@ function setupRouter(cfg, db, log) {
   r.get('/settings/prompts', promptOverrides.list);
   r.put('/settings/prompts/:key', promptOverrides.update);
   r.delete('/settings/prompts/:key', promptOverrides.reset);
+
+  // ---------- scene model map ----------
+  r.get('/scene-model-map', sceneModelMap.list);
+  r.post('/scene-model-map', sceneModelMap.create);
+  r.get('/scene-model-map/:key', sceneModelMap.get);
+  r.put('/scene-model-map/:key', sceneModelMap.update);
+  r.delete('/scene-model-map/:key', sceneModelMap.delete);
 
   // 启动时将已有的覆盖加载到 promptI18n 内存缓存
   try {

--- a/backend-node/src/routes/sceneModelMap.js
+++ b/backend-node/src/routes/sceneModelMap.js
@@ -1,0 +1,123 @@
+const response = require('../response');
+
+function list(db, log) {
+  return (req, res) => {
+    try {
+      const rows = db.prepare('SELECT * FROM ai_model_map ORDER BY key').all();
+      response.success(res, rows);
+    } catch (err) {
+      log.error('List scene model map failed', { error: err.message });
+      response.internalError(res, '获取场景模型映射失败');
+    }
+  };
+}
+
+function get(db, log) {
+  return (req, res) => {
+    const { key } = req.params;
+    try {
+      const row = db.prepare('SELECT * FROM ai_model_map WHERE key = ?').get(key);
+      if (!row) {
+        return response.notFound(res, '场景模型映射不存在');
+      }
+      response.success(res, row);
+    } catch (err) {
+      log.error('Get scene model map failed', { error: err.message, key });
+      response.internalError(res, '获取场景模型映射失败');
+    }
+  };
+}
+
+function create(db, log) {
+  return (req, res) => {
+    const body = req.body || {};
+    const { key, service_type = 'text', config_id, model_override, description } = body;
+    
+    if (!key) {
+      return response.badRequest(res, '缺少必填字段: key');
+    }
+    
+    const now = new Date().toISOString();
+    try {
+      // 检查 key 是否已存在
+      const existing = db.prepare('SELECT id FROM ai_model_map WHERE key = ?').get(key);
+      if (existing) {
+        return response.badRequest(res, '场景键已存在');
+      }
+      
+      const result = db.prepare(`
+        INSERT INTO ai_model_map (key, service_type, config_id, model_override, description, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(key, service_type, config_id || null, model_override || null, description || '', now, now);
+      
+      const row = db.prepare('SELECT * FROM ai_model_map WHERE id = ?').get(result.lastInsertRowid);
+      response.created(res, row);
+    } catch (err) {
+      log.error('Create scene model map failed', { error: err.message, key });
+      response.internalError(res, '创建场景模型映射失败');
+    }
+  };
+}
+
+function update(db, log) {
+  return (req, res) => {
+    const { key } = req.params;
+    const body = req.body || {};
+    const { service_type, config_id, model_override, description } = body;
+    
+    const now = new Date().toISOString();
+    try {
+      const existing = db.prepare('SELECT id FROM ai_model_map WHERE key = ?').get(key);
+      if (!existing) {
+        return response.notFound(res, '场景模型映射不存在');
+      }
+      
+      db.prepare(`
+        UPDATE ai_model_map 
+        SET service_type = ?, config_id = ?, model_override = ?, description = ?, updated_at = ?
+        WHERE key = ?
+      `).run(
+        service_type || 'text',
+        config_id !== undefined ? config_id : null,
+        model_override !== undefined ? model_override : null,
+        description !== undefined ? description : '',
+        now,
+        key
+      );
+      
+      const row = db.prepare('SELECT * FROM ai_model_map WHERE key = ?').get(key);
+      response.success(res, row);
+    } catch (err) {
+      log.error('Update scene model map failed', { error: err.message, key });
+      response.internalError(res, '更新场景模型映射失败');
+    }
+  };
+}
+
+function remove(db, log) {
+  return (req, res) => {
+    const { key } = req.params;
+    try {
+      const existing = db.prepare('SELECT id FROM ai_model_map WHERE key = ?').get(key);
+      if (!existing) {
+        return response.notFound(res, '场景模型映射不存在');
+      }
+      
+      db.prepare('DELETE FROM ai_model_map WHERE key = ?').run(key);
+      response.success(res, { message: '删除成功' });
+    } catch (err) {
+      log.error('Delete scene model map failed', { error: err.message, key });
+      response.internalError(res, '删除场景模型映射失败');
+    }
+  };
+}
+
+module.exports = function sceneModelMapRoutes(db, log) {
+  return {
+    list: list(db, log),
+    get: get(db, log),
+    create: create(db, log),
+    update: update(db, log),
+    delete: remove(db, log)
+  };
+};

--- a/backend-node/src/services/backgroundExtractionService.js
+++ b/backend-node/src/services/backgroundExtractionService.js
@@ -27,6 +27,7 @@ async function translatePromptToChinese(db, log, model, prompt) {
     '请将以下场景图像提示词翻译为中文，保留风格词或比例（如 realistic、16:9）原样，直接返回翻译后的中文提示词，不要解释：\n' +
     prompt;
   const text = await aiClient.generateText(db, log, 'text', userPrompt, '', {
+    scene_key: 'scene_extraction',
     model: model || undefined,
     temperature: 0.2,
     max_tokens: 400,
@@ -40,7 +41,7 @@ async function extractBackgroundsFromScript(db, cfg, log, scriptContent, dramaId
   const prompt = (promptI18n.getLanguage(cfg) === 'en' ? '[Script Content]\n' : '【剧本内容】\n') + scriptContent;
   console.log('systemPrompt', systemPrompt);
   console.log('prompt', prompt);
-  const text = await aiClient.generateText(db, log, 'text', prompt, systemPrompt, { model: model || undefined, temperature: 0.7 });
+  const text = await aiClient.generateText(db, log, 'text', prompt, systemPrompt, { scene_key: 'scene_extraction', model: model || undefined, temperature: 0.7 });
   let list = [];
   try {
     const parsed = safeParseAIJSON(text, log);

--- a/backend-node/src/services/characterGenerationService.js
+++ b/backend-node/src/services/characterGenerationService.js
@@ -16,6 +16,7 @@ async function enrichIdentityAnchors(db, log, characterId, appearance) {
     const systemPrompt = promptI18n.getIdentityAnchorsPrompt();
     const userPrompt = `Character appearance description:\n${appearance}`;
     const raw = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, {
+      scene_key: 'identity_anchors',
       max_tokens: 800,
       temperature: 0.1,
     });
@@ -73,6 +74,7 @@ async function processCharacterGeneration(db, cfg, log, taskID, req) {
   let text;
   try {
     text = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, {
+      scene_key: 'role_extraction',
       model: req.model || undefined,
       temperature,
       max_tokens: maxTokensForChars,

--- a/backend-node/src/services/characterLibraryService.js
+++ b/backend-node/src/services/characterLibraryService.js
@@ -431,6 +431,7 @@ async function generateCharacterPromptOnly(db, log, cfg, characterId, modelName,
   let fourViewDescription;
   try {
     fourViewDescription = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, {
+      scene_key: 'role_image_polish',
       model: modelName || undefined,
       max_tokens: 4000,
     });
@@ -487,6 +488,7 @@ async function generateCharacterFourViewImage(db, log, cfg, characterId, modelNa
     let fourViewDescription;
     try {
       fourViewDescription = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, {
+        scene_key: 'role_image_polish',
         model: modelName || undefined,
         max_tokens: 4000,
       });

--- a/backend-node/src/services/episodeStoryboardService.js
+++ b/backend-node/src/services/episodeStoryboardService.js
@@ -37,6 +37,7 @@ async function generateTextForStoryboard(db, log, userPrompt, systemPrompt, opti
   log.info('Storyboard generateText attempt 1', { model: model || '(default)', max_tokens: DEFAULT_STORYBOARD_MAX_TOKENS });
   try {
     const text = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, {
+      scene_key: 'storyboard_extraction',
       model: model || undefined,
       temperature,
       max_tokens: DEFAULT_STORYBOARD_MAX_TOKENS,
@@ -52,6 +53,7 @@ async function generateTextForStoryboard(db, log, userPrompt, systemPrompt, opti
       // 第二次尝试：不传 max_tokens，让模型用自己默认值
       log.info('Storyboard generateText attempt 2 (no max_tokens)', { model: model || '(default)' });
       const text = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, {
+        scene_key: 'storyboard_extraction',
         model: model || undefined,
         temperature,
         streamCallback,

--- a/backend-node/src/services/framePromptService.js
+++ b/backend-node/src/services/framePromptService.js
@@ -238,7 +238,7 @@ async function generateSingleFrame(db, log, cfg, sb, scene, characterNames, mode
 
   let aiResponse;
   try {
-    aiResponse = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, { model: model || undefined, max_tokens: 800 });
+    aiResponse = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, { scene_key: 'frame_prompt', model: model || undefined, max_tokens: 800 });
   } catch (err) {
     log.warn('Frame prompt AI failed, using fallback', { error: err.message });
     const suffix = frameKind === 'first' ? 'first frame, static shot' : frameKind === 'key' ? 'key frame, dynamic action' : 'last frame, final state';

--- a/backend-node/src/services/novelImportService.js
+++ b/backend-node/src/services/novelImportService.js
@@ -63,6 +63,7 @@ ${truncated}
 
   try {
     const result = await aiClient.generateText(db, log, 'text', userPrompt, null, {
+      scene_key: 'novel_import',
       max_tokens: 800,
       temperature: 0.7,
     });

--- a/backend-node/src/services/propExtractionService.js
+++ b/backend-node/src/services/propExtractionService.js
@@ -48,6 +48,7 @@ async function processPropExtraction(db, log, taskId, episodeId) {
   let response;
   try {
     response = await aiClient.generateText(db, log, 'text', prompt, systemPrompt, {
+      scene_key: 'prop_extraction',
       max_tokens: 2000,
       temperature: 0.3,
     });

--- a/backend-node/src/services/propService.js
+++ b/backend-node/src/services/propService.js
@@ -151,6 +151,7 @@ async function generatePropPromptOnly(db, log, cfg, propId, modelName, style) {
   let generatedPrompt;
   try {
     generatedPrompt = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, {
+      scene_key: 'prop_image_polish',
       model: modelName || undefined,
       max_tokens: 800,
     });

--- a/backend-node/src/services/sceneService.js
+++ b/backend-node/src/services/sceneService.js
@@ -180,6 +180,7 @@ async function generateScenePromptOnly(db, log, cfg, sceneId, modelName, style) 
   let fourViewDescription;
   try {
     fourViewDescription = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, {
+      scene_key: 'scene_image_polish',
       model: modelName || undefined,
       max_tokens: 4000,
     });
@@ -243,6 +244,7 @@ async function generateSceneFourViewImage(db, log, cfg, sceneId, modelName, styl
     let fourViewDescription;
     try {
       fourViewDescription = await aiClient.generateText(db, log, 'text', userMsg, systemPrompt, {
+        scene_key: 'scene_image_polish',
         model: modelName || undefined,
         max_tokens: 4000,
       });

--- a/backend-node/src/services/storyGenerationService.js
+++ b/backend-node/src/services/storyGenerationService.js
@@ -24,6 +24,7 @@ async function generateStory(db, log, body) {
   // 注意：不使用 json_mode=true，因为 response_format:json_object 要求返回 JSON 对象而非数组，
   // 会导致模型将数组包成 {"episodes":[...]} 对象，破坏解析逻辑。依靠 prompt 本身约束格式即可。
   const rawText = await aiClient.generateText(db, log, 'text', userPrompt, systemPrompt, {
+    scene_key: 'story_generation',
     model: body.model || undefined,
     temperature: 0.8,
     min_max_tokens: minTokensNeeded,

--- a/frontweb/src/api/sceneModelMap.js
+++ b/frontweb/src/api/sceneModelMap.js
@@ -1,0 +1,19 @@
+import request from '@/utils/request'
+
+export const sceneModelMapAPI = {
+  list() {
+    return request.get('/scene-model-map')
+  },
+  get(key) {
+    return request.get(`/scene-model-map/${key}`)
+  },
+  create(body) {
+    return request.post('/scene-model-map', body)
+  },
+  update(key, body) {
+    return request.put(`/scene-model-map/${key}`, body)
+  },
+  delete(key) {
+    return request.delete(`/scene-model-map/${key}`)
+  }
+}

--- a/frontweb/src/components/AIConfigContent.vue
+++ b/frontweb/src/components/AIConfigContent.vue
@@ -110,6 +110,11 @@
           <PromptEditor />
         </div>
       </el-tab-pane>
+      <el-tab-pane label="高级设置（业务场景）" name="sceneModelMap">
+        <div class="tab-content">
+          <SceneModelMap />
+        </div>
+      </el-tab-pane>
       <el-tab-pane label="生成设置" name="generation">
         <div class="tab-content generation-settings">
           <div class="gs-section-title">⚡ 一键生成并发设置</div>
@@ -925,6 +930,7 @@ import { Plus, MagicStick, QuestionFilled, Download, Upload, Delete, ChatDotRoun
 import { aiAPI } from '@/api/ai'
 import { generationSettingsAPI } from '@/api/prompts'
 import PromptEditor from '@/components/PromptEditor.vue'
+import SceneModelMap from '@/components/SceneModelMap.vue'
 
 const activeTab = ref('configs')
 const importFileRef = ref(null)
@@ -1802,6 +1808,8 @@ onMounted(() => {
 }
 .tab-content {
   padding-top: 16px;
+  max-height: calc(100vh - 320px);
+  overflow-y: auto;
 }
 .content-actions {
   display: flex;

--- a/frontweb/src/components/PromptEditor.vue
+++ b/frontweb/src/components/PromptEditor.vue
@@ -2,60 +2,96 @@
   <div class="prompt-editor-page">
     <div v-if="loading" v-loading="true" class="loading-wrap" />
     <template v-else>
-      <p class="page-desc">
-        可自定义 AI 生成各阶段使用的提示词（System Prompt）。蓝色锁定区为 JSON 格式要求，不可修改以确保输出格式正确。
-      </p>
-      <div v-for="p in prompts" :key="p.key" class="prompt-card">
-        <div class="prompt-card-header">
-          <div class="prompt-card-meta">
-            <span class="prompt-label">{{ p.label }}</span>
-            <el-tag v-if="p.is_customized" type="warning" size="small" class="custom-tag">已自定义</el-tag>
-            <el-tag v-else type="info" size="small" class="custom-tag">使用默认</el-tag>
+      <div class="editor-layout">
+        <!-- 左侧菜单 -->
+        <div class="left-sidebar">
+          <div class="sidebar-menu">
+            <div
+              v-for="p in prompts"
+              :key="p.key"
+              :class="['menu-item', { active: currentKey === p.key }]"
+              @click="selectPrompt(p.key)"
+            >
+              <div class="menu-item-content">
+                <span class="menu-label">{{ p.label }}</span>
+                <el-tag
+                  v-if="p.is_customized"
+                  type="warning"
+                  size="small"
+                  class="menu-tag"
+                >已自定义</el-tag>
+                <el-tag v-else type="info" size="small" class="menu-tag">默认</el-tag>
+              </div>
+              <div v-if="isDirty[p.key]" class="dirty-indicator" />
+            </div>
           </div>
-          <p class="prompt-desc">{{ p.description }}</p>
         </div>
 
-        <div class="prompt-edit-section">
-          <div class="section-label">
-            <el-icon class="section-icon"><Edit /></el-icon>
-            <span>指令内容（可编辑）</span>
-          </div>
-          <el-input
-            v-model="editState[p.key]"
-            type="textarea"
-            :rows="10"
-            :placeholder="p.default_body"
-            class="prompt-textarea"
-            @input="markDirty(p.key)"
-          />
-        </div>
+        <!-- 右侧编辑区 -->
+        <div class="right-content">
+          <p class="page-desc">
+            可自定义 AI 生成各阶段使用的提示词（System Prompt）。蓝色锁定区为 JSON
+            格式要求，不可修改以确保输出格式正确。
+          </p>
 
-        <div v-if="p.locked_suffix" class="prompt-locked-section">
-          <div class="section-label section-label--locked">
-            <el-icon class="section-icon"><Lock /></el-icon>
-            <span>JSON 格式要求（锁定，不可修改）</span>
-          </div>
-          <div class="locked-content">{{ p.locked_suffix }}</div>
-        </div>
+          <div v-if="currentPrompt" class="prompt-card">
+            <div class="prompt-card-header">
+              <div class="prompt-card-meta">
+                <span class="prompt-label">{{ currentPrompt.label }}</span>
+                <el-tag
+                  v-if="currentPrompt.is_customized"
+                  type="warning"
+                  size="small"
+                  class="custom-tag"
+                >已自定义</el-tag>
+                <el-tag v-else type="info" size="small" class="custom-tag">使用默认</el-tag>
+              </div>
+              <p class="prompt-desc">{{ currentPrompt.description }}</p>
+            </div>
 
-        <div class="prompt-actions">
-          <el-button
-            type="primary"
-            size="small"
-            :loading="savingKey === p.key"
-            :disabled="!isDirty[p.key]"
-            @click="save(p)"
-          >
-            保存
-          </el-button>
-          <el-button
-            size="small"
-            :loading="resettingKey === p.key"
-            :disabled="!p.is_customized && !isDirty[p.key]"
-            @click="reset(p)"
-          >
-            恢复默认
-          </el-button>
+            <div class="prompt-edit-section">
+              <div class="section-label">
+                <el-icon class="section-icon"><Edit /></el-icon>
+                <span>指令内容（可编辑）</span>
+              </div>
+              <el-input
+                v-model="editState[currentPrompt.key]"
+                type="textarea"
+                :rows="16"
+                :placeholder="currentPrompt.default_body"
+                class="prompt-textarea"
+                @input="markDirty(currentPrompt.key)"
+              />
+            </div>
+
+            <div v-if="currentPrompt.locked_suffix" class="prompt-locked-section">
+              <div class="section-label section-label--locked">
+                <el-icon class="section-icon"><Lock /></el-icon>
+                <span>JSON 格式要求（锁定，不可修改）</span>
+              </div>
+              <div class="locked-content">{{ currentPrompt.locked_suffix }}</div>
+            </div>
+
+            <div class="prompt-actions">
+              <el-button
+                type="primary"
+                size="small"
+                :loading="savingKey === currentPrompt.key"
+                :disabled="!isDirty[currentPrompt.key]"
+                @click="save(currentPrompt)"
+              >
+                保存
+              </el-button>
+              <el-button
+                size="small"
+                :loading="resettingKey === currentPrompt.key"
+                :disabled="!currentPrompt.is_customized && !isDirty[currentPrompt.key]"
+                @click="reset(currentPrompt)"
+              >
+                恢复默认
+              </el-button>
+            </div>
+          </div>
         </div>
       </div>
     </template>
@@ -63,7 +99,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Edit, Lock } from '@element-plus/icons-vue'
 import { promptsAPI } from '@/api/prompts'
@@ -74,6 +110,11 @@ const editState = ref({})
 const isDirty = ref({})
 const savingKey = ref(null)
 const resettingKey = ref(null)
+const currentKey = ref(null)
+
+const currentPrompt = computed(() => {
+  return prompts.value.find((p) => p.key === currentKey.value)
+})
 
 async function load() {
   loading.value = true
@@ -83,11 +124,19 @@ async function load() {
     for (const p of prompts.value) {
       editState.value[p.key] = p.current_body || p.default_body
     }
+    // 默认选中第一个
+    if (prompts.value.length > 0) {
+      currentKey.value = prompts.value[0].key
+    }
   } catch (_) {
     ElMessage.error('加载提示词失败')
   } finally {
     loading.value = false
   }
+}
+
+function selectPrompt(key) {
+  currentKey.value = key
 }
 
 function markDirty(key) {
@@ -117,7 +166,9 @@ async function save(p) {
 }
 
 async function reset(p) {
-  await ElMessageBox.confirm(`确定将「${p.label}」恢复为系统默认提示词？`, '恢复默认', { type: 'warning' })
+  await ElMessageBox.confirm(`确定将「${p.label}」恢复为系统默认提示词？`, '恢复默认', {
+    type: 'warning',
+  })
   resettingKey.value = p.key
   try {
     await promptsAPI.reset(p.key)
@@ -138,10 +189,104 @@ onMounted(() => load())
 <style scoped>
 .prompt-editor-page {
   padding: 0;
+  height: 100%;
 }
 .loading-wrap {
   min-height: 200px;
 }
+
+/* 左右布局 */
+.editor-layout {
+  display: flex;
+  height: 100%;
+  min-height: calc(100vh - 120px);
+}
+
+/* 左侧菜单 */
+.left-sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  background: var(--bg-card, #fff);
+  border-right: 1px solid var(--border-color, #e4e4e7);
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color, #e4e4e7);
+}
+
+.sidebar-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-bright, #18181b);
+}
+
+.sidebar-menu {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.menu-item {
+  padding: 12px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-bottom: 4px;
+  position: relative;
+}
+
+.menu-item:hover {
+  background: var(--bg-inner, #f8f8f8);
+}
+
+.menu-item.active {
+  background: var(--el-color-primary-light-9, #f3e8ff);
+}
+
+.menu-item.active .menu-label {
+  color: var(--el-color-primary, #7c3aed);
+  font-weight: 600;
+}
+
+.menu-item-content {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.menu-label {
+  font-size: 13px;
+  color: var(--text-bright, #18181b);
+  flex: 1;
+}
+
+.menu-tag {
+  font-size: 10px;
+  transform: scale(0.9);
+}
+
+.dirty-indicator {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 6px;
+  height: 6px;
+  background: var(--el-color-warning, #f59e0b);
+  border-radius: 50%;
+}
+
+/* 右侧内容区 */
+.right-content {
+  flex: 1;
+  padding: 20px;
+  overflow-y: auto;
+}
+
 .page-desc {
   margin: 0 0 20px;
   font-size: 13px;
@@ -152,35 +297,41 @@ onMounted(() => load())
   border-radius: 8px;
   border-left: 3px solid var(--el-color-primary, #7c3aed);
 }
+
 .prompt-card {
   background: var(--bg-card, #fff);
   border: 1px solid var(--border-color, #e4e4e7);
   border-radius: 12px;
   padding: 20px;
-  margin-bottom: 20px;
 }
+
 .prompt-card-header {
   margin-bottom: 16px;
 }
+
 .prompt-card-meta {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-bottom: 6px;
 }
+
 .prompt-label {
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 600;
   color: var(--text-bright, #18181b);
 }
+
 .custom-tag {
   font-size: 11px;
 }
+
 .prompt-desc {
   margin: 0;
   font-size: 12px;
   color: var(--text-muted, #71717a);
 }
+
 .section-label {
   display: flex;
   align-items: center;
@@ -190,23 +341,29 @@ onMounted(() => load())
   font-weight: 500;
   color: var(--text-muted, #71717a);
 }
+
 .section-label--locked {
   color: #2563eb;
 }
+
 .section-icon {
   font-size: 13px;
 }
+
 .prompt-edit-section {
-  margin-bottom: 12px;
+  margin-bottom: 16px;
 }
+
 .prompt-textarea :deep(textarea) {
   font-family: 'Consolas', 'Monaco', monospace;
   font-size: 12.5px;
   line-height: 1.6;
 }
+
 .prompt-locked-section {
   margin-bottom: 16px;
 }
+
 .locked-content {
   background: #eff6ff;
   border: 1px solid #bfdbfe;
@@ -219,11 +376,12 @@ onMounted(() => load())
   line-height: 1.6;
   user-select: none;
 }
+
 .prompt-actions {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
-  padding-top: 12px;
+  padding-top: 16px;
   border-top: 1px solid var(--border-color, #e4e4e7);
 }
 </style>

--- a/frontweb/src/components/SceneModelMap.vue
+++ b/frontweb/src/components/SceneModelMap.vue
@@ -1,0 +1,452 @@
+<template>
+  <div class="scene-model-map-page">
+    <div class="page-header">
+      <div class="header-left">
+        <p class="page-desc">
+          配置不同业务场景使用的 AI 模型路由。当调用 generateText 时传入 scene_key，系统会优先使用此处配置的模型。
+        </p>
+      </div>
+      <div class="header-right">
+        <el-button type="primary" @click="openAdd">
+          <el-icon><Plus /></el-icon>
+          添加业务场景配置
+        </el-button>
+      </div>
+    </div>
+
+    <div v-if="loading" v-loading="true" class="loading-wrap" />
+    
+    <template v-else>
+      <el-table
+        :data="list"
+        stripe
+        style="width: 100%"
+      >
+        <el-table-column prop="key" label="场景键 (scene_key)" min-width="220">
+          <template #default="{ row }">
+            <div class="">
+              <code class="scene-key">{{ row.key }}</code>
+              <span class="scene-key-label">{{ getSceneKeyLabel(row.key) }}</span>
+            </div>
+          </template>
+        </el-table-column>
+        <el-table-column prop="service_type" label="服务类型" width="120">
+          <template #default="{ row }">
+            <el-tag :type="serviceTypeTagType(row.service_type)" size="small">
+              {{ serviceTypeLabel(row.service_type) }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="config_name" label="AI 配置" min-width="180">
+          <template #default="{ row }">
+            <span v-if="row.config_id">{{ row.config_name || '配置 #' + row.config_id }}</span>
+            <el-tag v-else type="info" size="small">使用默认配置</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="model_override" label="模型覆盖" min-width="180">
+          <template #default="{ row }">
+            <span v-if="row.model_override" class="model-override">{{ row.model_override }}</span>
+            <span v-else class="text-muted">使用配置默认模型</span>
+          </template>
+        </el-table-column>
+        <el-table-column prop="description" label="描述" min-width="200" show-overflow-tooltip />
+        <el-table-column label="操作" width="150" fixed="right">
+          <template #default="{ row }">
+            <el-button link type="primary" size="small" @click="openEdit(row)">编辑</el-button>
+            <el-button link type="danger" size="small" @click="onDelete(row)">删除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-empty v-if="list.length === 0" description="暂无场景模型映射配置" />
+    </template>
+
+    <!-- 添加/编辑对话框 -->
+    <el-dialog
+      v-model="dialogVisible"
+      :title="editingKey ? '编辑业务场景映射' : '添加业务场景映射'"
+      width="560px"
+      :close-on-click-modal="false"
+      @closed="resetForm"
+    >
+      <el-form ref="formRef" :model="form" :rules="rules" label-width="120px">
+        <el-form-item prop="key" label="场景键">
+          <el-select
+            v-model="form.key"
+            filterable
+            allow-create
+            default-first-option
+            placeholder="选择或输入场景键"
+            style="width: 100%"
+            :disabled="!!editingKey"
+            @change="onKeyChange"
+          >
+            <el-option
+              v-for="k in predefinedKeys"
+              :key="k.value"
+              :label="k.label"
+              :value="k.value"
+            />
+          </el-select>
+          <p class="field-tip">用于在代码中标识业务场景，选择后会自动设置对应的服务类型</p>
+        </el-form-item>
+
+        <el-form-item prop="service_type" label="服务类型">
+          <el-select v-model="form.service_type" placeholder="选择服务类型" style="width: 100%" disabled>
+            <el-option label="文本/对话" value="text" />
+            <el-option label="文本生成图片" value="image" />
+            <el-option label="分镜图片生成" value="storyboard_image" />
+            <el-option label="视频生成" value="video" />
+            <el-option label="语音合成 TTS" value="tts" />
+          </el-select>
+          <p class="field-tip">由场景键自动决定，不可更改</p>
+        </el-form-item>
+
+        <el-form-item label="AI 配置">
+          <el-select
+            v-model="form.config_id"
+            clearable
+            placeholder="选择 AI 配置（留空使用默认）"
+            style="width: 100%"
+            @change="onConfigChange"
+          >
+            <el-option
+              v-for="c in filteredConfigs"
+              :key="c.id"
+              :label="`${c.name} (${c.provider})`"
+              :value="c.id"
+            />
+          </el-select>
+          <p class="field-tip">指定具体的 AI 服务配置，不选则使用该类服务的默认配置</p>
+        </el-form-item>
+
+        <el-form-item label="模型覆盖">
+          <el-select
+            v-model="form.model_override"
+            clearable
+            placeholder="选择模型（留空使用配置默认）"
+            style="width: 100%"
+            :disabled="!selectedConfigModels.length"
+          >
+            <el-option
+              v-for="m in selectedConfigModels"
+              :key="m"
+              :label="m"
+              :value="m"
+            />
+          </el-select>
+          <p class="field-tip">
+            {{ selectedConfigModels.length ? '从该配置的可用模型中选择' : '请先选择 AI 配置' }}
+          </p>
+        </el-form-item>
+        <el-form-item prop="description" label="描述">
+          <el-input
+            v-model="form.description"
+            placeholder="输入场景描述，便于理解用途"
+          />
+        </el-form-item>
+      </el-form>
+
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="save">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { Plus } from '@element-plus/icons-vue'
+import { sceneModelMapAPI } from '@/api/sceneModelMap'
+import { aiAPI } from '@/api/ai'
+
+const loading = ref(false)
+const saving = ref(false)
+const list = ref([])
+const configs = ref([])
+const dialogVisible = ref(false)
+const editingKey = ref(null)
+const formRef = ref(null)
+
+const form = ref({
+  key: '',
+  description: '',
+  service_type: 'text',
+  config_id: null,
+  model_override: ''
+})
+
+const rules = {
+  key: [{ required: true, message: '请输入场景键', trigger: 'blur' }],
+  service_type: [{ required: true, message: '请选择服务类型', trigger: 'change' }]
+}
+
+// 预定义场景键及其对应的服务类型
+const predefinedKeys = [
+  { value: 'image_polish', label: 'image_polish - 分镜图提示词润色', service_type: 'text' },
+  // 目前程序里只内置了一个场景键：image_polish
+  // 以下为新增的场景键，已添加到对应的接口里
+  { value: 'role_image_polish', label: 'role_image_polish - 角色图提示词润色', service_type: 'text' },
+  { value: 'prop_image_polish', label: 'prop_image_polish - 道具图提示词润色', service_type: 'text' },
+  { value: 'scene_image_polish', label: 'scene_image_polish - 场景图提示词润色', service_type: 'text' },
+  { value: 'role_extraction', label: 'role_extraction - 角色提取', service_type: 'text' },
+  { value: 'prop_extraction', label: 'prop_extraction - 道具提取', service_type: 'text' },
+  { value: 'scene_extraction', label: 'scene_extraction - 场景提取', service_type: 'text' },
+  { value: 'storyboard_extraction', label: 'storyboard_extraction - 分镜生成', service_type: 'text' },
+  { value: 'identity_anchors', label: 'identity_anchors - 角色视觉锚点提炼', service_type: 'text' },
+  { value: 'frame_prompt', label: 'frame_prompt - 帧提示词生成', service_type: 'text' },
+  { value: 'novel_import', label: 'novel_import - 小说导入改写', service_type: 'text' },
+  { value: 'story_generation', label: 'story_generation - 故事生成', service_type: 'text' },
+  //  以下是其他服务类型...未实现
+  // 图片生成
+  // { value: 'role_image_gen', label: 'role_image_gen - 角色图片生成', service_type: 'image' },
+  // { value: 'prop_image_gen', label: 'prop_image_gen - 道具图片生成', service_type: 'image' },
+  // { value: 'scene_image_gen', label: 'scene_image_gen - 场景图片生成', service_type: 'image' },
+  // { value: 'storyboard_image_gen', label: 'storyboard_image_gen - 分镜图片生成', service_type: 'image' },
+  // { value: 'video_frame_gen', label: 'video_frame_gen - 视频帧生成', service_type: 'video' },// 首尾帧视频生成
+  // { value: 'video_full_gen', label: 'video_full_gen - 全能视频生成', service_type: 'video' },// 全能模式视频生成
+]
+
+// 根据服务类型筛选配置
+const filteredConfigs = computed(() => {
+  const currentServiceType = form.value.service_type
+  console.log('filteredConfigs computed, service_type:', currentServiceType, 'configs:', configs.value.length)
+  const filtered = configs.value.filter(c => {
+    const match = c.service_type === currentServiceType && c.is_active
+    console.log('  config:', c.name, 'service_type:', c.service_type, 'match:', match)
+    return match
+  })
+  console.log('  filtered result:', filtered.length)
+  return filtered
+})
+
+// 获取选中配置的可用模型列表
+const selectedConfigModels = computed(() => {
+  if (!form.value.config_id) return []
+  const config = configs.value.find(c => c.id === form.value.config_id)
+  if (!config) return []
+  // 模型可能是数组或逗号/换行分隔的字符串
+  const models = config.model
+  if (Array.isArray(models)) return models
+  if (typeof models === 'string') {
+    return models.split(/[\n,，]/).map(s => s.trim()).filter(Boolean)
+  }
+  return config.default_model ? [config.default_model] : []
+})
+
+function serviceTypeLabel(type) {
+  const map = {
+    text: '文本/对话',
+    image: '文本生成图片',
+    storyboard_image: '分镜图片生成',
+    video: '视频生成',
+    tts: '语音合成 TTS'
+  }
+  return map[type] || type
+}
+
+function serviceTypeTagType(type) {
+  const map = {
+    text: 'primary',
+    image: 'success',
+    storyboard_image: 'warning',
+    video: 'danger',
+    tts: 'info'
+  }
+  return map[type] || ''
+}
+
+// 获取场景键的 label
+function getSceneKeyLabel(key) {
+  const matched = predefinedKeys.find(k => k.value === key)
+  if (matched) {
+    // 从 label 中提取描述部分（去掉 key 前缀）
+    return matched.label.replace(matched.value + ' - ', '')
+  }
+  return ''
+}
+
+// 场景键改变时自动设置服务类型
+function onKeyChange(key) {
+  console.log('onKeyChange called with key:', key)
+  const matched = predefinedKeys.find(k => k.value === key)
+  console.log('matched predefined key:', matched)
+  if (matched) {
+    form.value.service_type = matched.service_type
+    console.log('service_type set to:', form.value.service_type)
+  }
+  // 重置配置和模型选择
+  form.value.config_id = null
+  form.value.model_override = ''
+}
+
+// 配置改变时重置模型选择
+function onConfigChange(configId) {
+  form.value.model_override = ''
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const [mapsData, configsData] = await Promise.all([
+      sceneModelMapAPI.list(),
+      aiAPI.list()
+    ])
+    configs.value = configsData || []
+    console.log('Loaded configs:', configs.value.map(c => ({ id: c.id, name: c.name, service_type: c.service_type, is_active: c.is_active })))
+    
+    // 合并配置名称
+    list.value = (mapsData || []).map(item => {
+      const config = configs.value.find(c => c.id === item.config_id)
+      return {
+        ...item,
+        config_name: config?.name || null
+      }
+    })
+  } catch (err) {
+    ElMessage.error('加载场景模型映射失败: ' + (err.message || '未知错误'))
+  } finally {
+    loading.value = false
+  }
+}
+
+function openAdd() {
+  editingKey.value = null
+  form.value = {
+    key: '',
+    description: '',
+    service_type: 'text',
+    config_id: null,
+    model_override: ''
+  }
+  dialogVisible.value = true
+}
+
+function openEdit(row) {
+  editingKey.value = row.key
+  form.value = {
+    key: row.key,
+    description: row.description || '',
+    service_type: row.service_type || 'text',
+    config_id: row.config_id || null,
+    model_override: row.model_override || ''
+  }
+  dialogVisible.value = true
+}
+
+async function save() {
+  const valid = await formRef.value?.validate().catch(() => false)
+  if (!valid) return
+
+  saving.value = true
+  try {
+    const body = {
+      description: form.value.description,
+      service_type: form.value.service_type,
+      config_id: form.value.config_id || null,
+      model_override: form.value.model_override || null
+    }
+    
+    if (editingKey.value) {
+      await sceneModelMapAPI.update(editingKey.value, body)
+      ElMessage.success('更新成功')
+    } else {
+      await sceneModelMapAPI.create({ ...body, key: form.value.key })
+      ElMessage.success('创建成功')
+    }
+    dialogVisible.value = false
+    await load()
+  } catch (err) {
+    ElMessage.error('保存失败: ' + (err.message || '未知错误'))
+  } finally {
+    saving.value = false
+  }
+}
+
+async function onDelete(row) {
+  try {
+    await ElMessageBox.confirm(
+      `确定要删除场景 "${row.key}" 的模型映射配置吗？`,
+      '确认删除',
+      { type: 'warning' }
+    )
+    await sceneModelMapAPI.delete(row.key)
+    ElMessage.success('删除成功')
+    await load()
+  } catch (err) {
+    if (err !== 'cancel') {
+      ElMessage.error('删除失败: ' + (err.message || '未知错误'))
+    }
+  }
+}
+
+function resetForm() {
+  formRef.value?.resetFields()
+}
+
+onMounted(() => {
+  load()
+})
+</script>
+
+<style scoped>
+.scene-model-map-page {
+  padding: 0;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.page-desc {
+  margin: 0;
+  color: #666;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.loading-wrap {
+  padding: 40px;
+}
+
+.scene-key {
+  background: #f5f7fa;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-family: 'Courier New', monospace;
+  font-size: 13px;
+  color: #409eff;
+  width: fit-content;
+}
+
+.scene-key-label {
+  font-size: 12px;
+  color: #666;
+}
+
+.model-override {
+  background: #e6f7ff;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-family: 'Courier New', monospace;
+  font-size: 13px;
+  color: #096dd9;
+}
+
+.text-muted {
+  color: #999;
+  font-size: 13px;
+}
+
+.field-tip {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #999;
+  line-height: 1.4;
+}
+</style>


### PR DESCRIPTION
## 改动说明 / Description

新增场景模型映射功能，允许为不同业务场景配置特定的AI模型和配置。主要变更包括：

1. 在多个服务中添加 scene_key 参数以标识业务场景
2. 新增场景模型映射的前后端实现，包括数据库表、API接口和UI界面
3. 重构提示词编辑器UI，优化用户体验
4. 更新.gitignore忽略.DS_Store文件

基于系统原有的功能拓展，该功能使得系统可以根据业务场景自动选择合适的AI模型和配置，提高灵活性和可配置性


## 改动类型 / Type of Change

- [ ] ✨ 新功能 / New feature
- [x] 🎨 UI/样式调整 / UI / style change


## 测试说明 / Testing

- [ ] 本地开发模式测试通过 / Tested in dev mode


## 截图 / Screenshots

提示词设置界面改为左右分局，更清晰
<img width="2974" height="1618" alt="提示词设置" src="https://github.com/user-attachments/assets/6eeab435-f67c-4bad-a96c-38d70fd72290" />

新增业务场景模型映射
<img width="2168" height="1246" alt="ScreenShot_2026-04-17_181238_357" src="https://github.com/user-attachments/assets/b488d633-82b6-4809-aaf1-e58e0f19e3cc" />


## 检查清单 / Checklist

- [ ] 代码符合项目现有风格（纯 JavaScript，无 TypeScript）/ Code follows project style (vanilla JS)
- [ ] 没有引入不必要的依赖 / No unnecessary new dependencies
- [ ] 如有必要，已更新相关文档 / Documentation updated if needed

