### PR TITLE
修复素材库和本剧库重复加入

### DIFF
--- a/backend-node/migrations/01_init.sql
+++ b/backend-node/migrations/01_init.sql
@@ -230,6 +230,7 @@ CREATE TABLE IF NOT EXISTS video_merges (
 
 CREATE TABLE IF NOT EXISTS character_libraries (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
+  drama_id INTEGER,
   name TEXT NOT NULL DEFAULT '',
   category TEXT,
   image_url TEXT,
@@ -237,6 +238,7 @@ CREATE TABLE IF NOT EXISTS character_libraries (
   description TEXT,
   tags TEXT,
   source_type TEXT,
+  source_id TEXT,
   created_at TEXT,
   updated_at TEXT,
   deleted_at TEXT
@@ -244,6 +246,7 @@ CREATE TABLE IF NOT EXISTS character_libraries (
 
 CREATE TABLE IF NOT EXISTS scene_libraries (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
+  drama_id INTEGER,
   location TEXT NOT NULL DEFAULT '',
   time TEXT,
   prompt TEXT,
@@ -253,6 +256,7 @@ CREATE TABLE IF NOT EXISTS scene_libraries (
   category TEXT,
   tags TEXT,
   source_type TEXT,
+  source_id TEXT,
   created_at TEXT,
   updated_at TEXT,
   deleted_at TEXT
@@ -260,6 +264,7 @@ CREATE TABLE IF NOT EXISTS scene_libraries (
 
 CREATE TABLE IF NOT EXISTS prop_libraries (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
+  drama_id INTEGER,
   name TEXT NOT NULL DEFAULT '',
   description TEXT,
   prompt TEXT,
@@ -268,6 +273,7 @@ CREATE TABLE IF NOT EXISTS prop_libraries (
   category TEXT,
   tags TEXT,
   source_type TEXT,
+  source_id TEXT,
   created_at TEXT,
   updated_at TEXT,
   deleted_at TEXT

--- a/backend-node/migrations/09_scene_prop_libraries.sql
+++ b/backend-node/migrations/09_scene_prop_libraries.sql
@@ -1,6 +1,7 @@
 -- 公共场景库、公共道具库（仿 character_libraries）
 CREATE TABLE IF NOT EXISTS scene_libraries (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
+  drama_id INTEGER,
   location TEXT NOT NULL DEFAULT '',
   time TEXT,
   prompt TEXT,
@@ -10,6 +11,7 @@ CREATE TABLE IF NOT EXISTS scene_libraries (
   category TEXT,
   tags TEXT,
   source_type TEXT,
+  source_id TEXT,
   created_at TEXT,
   updated_at TEXT,
   deleted_at TEXT
@@ -17,6 +19,7 @@ CREATE TABLE IF NOT EXISTS scene_libraries (
 
 CREATE TABLE IF NOT EXISTS prop_libraries (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
+  drama_id INTEGER,
   name TEXT NOT NULL DEFAULT '',
   description TEXT,
   prompt TEXT,
@@ -25,6 +28,7 @@ CREATE TABLE IF NOT EXISTS prop_libraries (
   category TEXT,
   tags TEXT,
   source_type TEXT,
+  source_id TEXT,
   created_at TEXT,
   updated_at TEXT,
   deleted_at TEXT

--- a/backend-node/migrations/22_library_source_id.sql
+++ b/backend-node/migrations/22_library_source_id.sql
@@ -1,0 +1,70 @@
+ALTER TABLE character_libraries ADD COLUMN drama_id INTEGER;
+ALTER TABLE scene_libraries ADD COLUMN drama_id INTEGER;
+ALTER TABLE prop_libraries ADD COLUMN drama_id INTEGER;
+
+ALTER TABLE character_libraries ADD COLUMN source_id TEXT;
+ALTER TABLE scene_libraries ADD COLUMN source_id TEXT;
+ALTER TABLE prop_libraries ADD COLUMN source_id TEXT;
+
+UPDATE character_libraries
+SET source_id = (
+  SELECT CAST(c.id AS TEXT)
+  FROM characters c
+  WHERE c.deleted_at IS NULL
+    AND character_libraries.source_type = 'character'
+    AND (character_libraries.drama_id IS NULL OR c.drama_id = character_libraries.drama_id)
+    AND (
+      (c.local_path IS NOT NULL AND c.local_path <> '' AND (
+        c.local_path = character_libraries.local_path
+        OR '/static/' || c.local_path = character_libraries.image_url
+      ))
+      OR (c.image_url IS NOT NULL AND c.image_url <> '' AND c.image_url = character_libraries.image_url)
+    )
+  ORDER BY c.id ASC
+  LIMIT 1
+)
+WHERE source_id IS NULL
+  AND deleted_at IS NULL
+  AND source_type = 'character';
+
+UPDATE scene_libraries
+SET source_id = (
+  SELECT CAST(s.id AS TEXT)
+  FROM scenes s
+  WHERE s.deleted_at IS NULL
+    AND scene_libraries.source_type = 'scene'
+    AND (scene_libraries.drama_id IS NULL OR s.drama_id = scene_libraries.drama_id)
+    AND (
+      (s.local_path IS NOT NULL AND s.local_path <> '' AND (
+        s.local_path = scene_libraries.local_path
+        OR '/static/' || s.local_path = scene_libraries.image_url
+      ))
+      OR (s.image_url IS NOT NULL AND s.image_url <> '' AND s.image_url = scene_libraries.image_url)
+    )
+  ORDER BY s.id ASC
+  LIMIT 1
+)
+WHERE source_id IS NULL
+  AND deleted_at IS NULL
+  AND source_type = 'scene';
+
+UPDATE prop_libraries
+SET source_id = (
+  SELECT CAST(p.id AS TEXT)
+  FROM props p
+  WHERE p.deleted_at IS NULL
+    AND prop_libraries.source_type = 'prop'
+    AND (prop_libraries.drama_id IS NULL OR p.drama_id = prop_libraries.drama_id)
+    AND (
+      (p.local_path IS NOT NULL AND p.local_path <> '' AND (
+        p.local_path = prop_libraries.local_path
+        OR '/static/' || p.local_path = prop_libraries.image_url
+      ))
+      OR (p.image_url IS NOT NULL AND p.image_url <> '' AND p.image_url = prop_libraries.image_url)
+    )
+  ORDER BY p.id ASC
+  LIMIT 1
+)
+WHERE source_id IS NULL
+  AND deleted_at IS NULL
+  AND source_type = 'prop';

--- a/backend-node/src/db/migrate.js
+++ b/backend-node/src/db/migrate.js
@@ -406,6 +406,7 @@ function ensureAllColumns(database) {
     { name: 'appearance',        type: 'TEXT' },
     { name: 'tags',              type: 'TEXT' },
     { name: 'source_type',       type: 'TEXT' },
+    { name: 'source_id',         type: 'TEXT' },
     { name: 'identity_anchors',  type: 'TEXT' },   // JSON: 6层视觉锚点（骨相/五官/辨识标记/色值/皮肤/发型）
     { name: 'style_tokens',      type: 'TEXT' },   // 风格词 token 列表
     { name: 'color_palette',     type: 'TEXT' },   // JSON: Hex 色值数组
@@ -427,6 +428,7 @@ function ensureAllColumns(database) {
     { name: 'category',    type: 'TEXT' },
     { name: 'tags',        type: 'TEXT' },
     { name: 'source_type', type: 'TEXT' },
+    { name: 'source_id',   type: 'TEXT' },
     { name: 'created_at',  type: 'TEXT' },
     { name: 'updated_at',  type: 'TEXT' },
     { name: 'deleted_at',  type: 'TEXT' },
@@ -443,6 +445,7 @@ function ensureAllColumns(database) {
     { name: 'category',    type: 'TEXT' },
     { name: 'tags',        type: 'TEXT' },
     { name: 'source_type', type: 'TEXT' },
+    { name: 'source_id',   type: 'TEXT' },
     { name: 'created_at',  type: 'TEXT' },
     { name: 'updated_at',  type: 'TEXT' },
     { name: 'deleted_at',  type: 'TEXT' },

--- a/backend-node/src/routes/characterLibrary.js
+++ b/backend-node/src/routes/characterLibrary.js
@@ -5,7 +5,7 @@ function routes(db, cfg, log) {
   return {
     list: (req, res) => {
       try {
-        const query = { page: req.query.page, page_size: req.query.page_size, drama_id: req.query.drama_id, global: req.query.global, category: req.query.category, source_type: req.query.source_type, keyword: req.query.keyword };
+        const query = { page: req.query.page, page_size: req.query.page_size, drama_id: req.query.drama_id, global: req.query.global, category: req.query.category, source_type: req.query.source_type, source_id: req.query.source_id, source_ids: req.query.source_ids, keyword: req.query.keyword };
         const { items, total, page, pageSize } = characterLibraryService.listLibraryItems(db, query);
         response.successWithPagination(res, items, total, page, pageSize);
       } catch (err) {

--- a/backend-node/src/routes/propLibrary.js
+++ b/backend-node/src/routes/propLibrary.js
@@ -5,7 +5,7 @@ function routes(db, cfg, log) {
   return {
     list: (req, res) => {
       try {
-        const query = { page: req.query.page, page_size: req.query.page_size, drama_id: req.query.drama_id, global: req.query.global, category: req.query.category, source_type: req.query.source_type, keyword: req.query.keyword };
+        const query = { page: req.query.page, page_size: req.query.page_size, drama_id: req.query.drama_id, global: req.query.global, category: req.query.category, source_type: req.query.source_type, source_id: req.query.source_id, source_ids: req.query.source_ids, keyword: req.query.keyword };
         const { items, total, page, pageSize } = propLibraryService.listLibraryItems(db, query);
         response.successWithPagination(res, items, total, page, pageSize);
       } catch (err) {

--- a/backend-node/src/routes/sceneLibrary.js
+++ b/backend-node/src/routes/sceneLibrary.js
@@ -5,7 +5,7 @@ function routes(db, cfg, log) {
   return {
     list: (req, res) => {
       try {
-        const query = { page: req.query.page, page_size: req.query.page_size, drama_id: req.query.drama_id, global: req.query.global, category: req.query.category, source_type: req.query.source_type, keyword: req.query.keyword };
+        const query = { page: req.query.page, page_size: req.query.page_size, drama_id: req.query.drama_id, global: req.query.global, category: req.query.category, source_type: req.query.source_type, source_id: req.query.source_id, source_ids: req.query.source_ids, keyword: req.query.keyword };
         const { items, total, page, pageSize } = sceneLibraryService.listLibraryItems(db, query);
         response.successWithPagination(res, items, total, page, pageSize);
       } catch (err) {

--- a/backend-node/src/services/characterLibraryService.js
+++ b/backend-node/src/services/characterLibraryService.js
@@ -9,6 +9,13 @@ const { mergeCfgStyleWithDrama } = require('../utils/dramaStyleMerge');
 const jimengMaterialHubService = require('./jimengMaterialHubService');
 const uploadService = require('./uploadService');
 const seedance2AssetGuards = require('../utils/seedance2AssetGuards');
+const {
+  appendSourceIdFilters,
+  findExistingLibraryItem,
+  insertLibraryItem,
+  normalizeSourceId,
+  updateLibraryItem: updateExistingLibraryItem,
+} = require('./libraryDedup');
 
 function applyStyleOverrideToCfg(cfg, styleOverride) {
   const o = (styleOverride || '').toString().trim();
@@ -110,6 +117,7 @@ function listLibraryItems(db, query) {
     sql += ' AND source_type = ?';
     params.push(query.source_type);
   }
+  sql = appendSourceIdFilters(query, sql, params);
   if (query.keyword) {
     sql += ' AND (name LIKE ? OR description LIKE ?)';
     const k = '%' + query.keyword + '%';
@@ -127,21 +135,19 @@ function listLibraryItems(db, query) {
 function createLibraryItem(db, log, req) {
   const now = new Date().toISOString();
   const sourceType = req.source_type || 'generated';
-  const info = db.prepare(
-    `INSERT INTO character_libraries (drama_id, name, category, image_url, local_path, description, tags, source_type, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  ).run(
-    req.drama_id ?? null,
-    req.name || '',
-    req.category ?? null,
-    req.image_url || '',
-    req.local_path ?? null,
-    req.description ?? null,
-    req.tags ?? null,
-    sourceType,
-    now,
-    now
-  );
+  const info = insertLibraryItem(db, 'character_libraries', {
+    drama_id: req.drama_id ?? null,
+    name: req.name || '',
+    category: req.category ?? null,
+    image_url: req.image_url || '',
+    local_path: req.local_path ?? null,
+    description: req.description ?? null,
+    tags: req.tags ?? null,
+    source_type: sourceType,
+    source_id: normalizeSourceId(req.source_id) || null,
+    created_at: now,
+    updated_at: now,
+  });
   log.info('Library item created', { item_id: info.lastInsertRowid });
   return getLibraryItem(db, String(info.lastInsertRowid));
 }
@@ -163,6 +169,7 @@ function updateLibraryItem(db, log, id, req) {
   if (req.image_url != null) { updates.push('image_url = ?'); params.push(req.image_url); }
   if (req.local_path != null) { updates.push('local_path = ?'); params.push(req.local_path); }
   if (req.source_type != null) { updates.push('source_type = ?'); params.push(req.source_type); }
+  if (req.source_id != null) { updates.push('source_id = ?'); params.push(normalizeSourceId(req.source_id)); }
   if (updates.length === 0) return getLibraryItem(db, id);
   params.push(new Date().toISOString(), Number(id));
   db.prepare('UPDATE character_libraries SET ' + updates.join(', ') + ', updated_at = ? WHERE id = ?').run(...params);
@@ -234,12 +241,32 @@ function addCharacterToLibrary(db, log, characterId, category) {
   if (!charRow.image_url && !charRow.local_path) return { ok: false, error: '角色还没有形象图片' };
   const now = new Date().toISOString();
   const imageUrl = resolveImageUrl(charRow.image_url, charRow.local_path);
-  const info = db.prepare(
-    `INSERT INTO character_libraries (drama_id, name, image_url, local_path, description, source_type, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, 'character', ?, ?)`
-  ).run(charRow.drama_id, charRow.name, imageUrl, charRow.local_path || null, charRow.description || null, now, now);
+  const fields = {
+    drama_id: charRow.drama_id,
+    name: charRow.name,
+    category: category ?? null,
+    image_url: imageUrl,
+    local_path: charRow.local_path || null,
+    description: charRow.description || null,
+    source_type: 'character',
+    source_id: normalizeSourceId(charRow.id),
+    updated_at: now,
+  };
+  const existing = findExistingLibraryItem(db, 'character_libraries', {
+    dramaId: charRow.drama_id,
+    sourceType: 'character',
+    sourceId: charRow.id,
+    imageUrl,
+    localPath: charRow.local_path,
+  });
+  if (existing) {
+    updateExistingLibraryItem(db, 'character_libraries', existing.id, fields);
+    log.info('Character library item reused', { character_id: characterId, drama_id: charRow.drama_id, library_item_id: existing.id });
+    return { ok: true, item: getLibraryItem(db, String(existing.id)), duplicated: true };
+  }
+  const info = insertLibraryItem(db, 'character_libraries', { ...fields, created_at: now });
   log.info('Character added to drama library', { character_id: characterId, drama_id: charRow.drama_id, library_item_id: info.lastInsertRowid });
-  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)) };
+  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)), duplicated: false };
 }
 
 // 加入全局素材库（drama_id = NULL）
@@ -249,12 +276,31 @@ function addCharacterToMaterialLibrary(db, log, characterId) {
   if (!charRow.image_url && !charRow.local_path) return { ok: false, error: '角色还没有形象图片' };
   const now = new Date().toISOString();
   const imageUrl = resolveImageUrl(charRow.image_url, charRow.local_path);
-  const info = db.prepare(
-    `INSERT INTO character_libraries (drama_id, name, image_url, local_path, description, source_type, created_at, updated_at)
-     VALUES (NULL, ?, ?, ?, ?, 'character', ?, ?)`
-  ).run(charRow.name, imageUrl, charRow.local_path || null, charRow.description || null, now, now);
+  const fields = {
+    drama_id: null,
+    name: charRow.name,
+    image_url: imageUrl,
+    local_path: charRow.local_path || null,
+    description: charRow.description || null,
+    source_type: 'character',
+    source_id: normalizeSourceId(charRow.id),
+    updated_at: now,
+  };
+  const existing = findExistingLibraryItem(db, 'character_libraries', {
+    dramaId: null,
+    sourceType: 'character',
+    sourceId: charRow.id,
+    imageUrl,
+    localPath: charRow.local_path,
+  });
+  if (existing) {
+    updateExistingLibraryItem(db, 'character_libraries', existing.id, fields);
+    log.info('Character material library item reused', { character_id: characterId, library_item_id: existing.id });
+    return { ok: true, item: getLibraryItem(db, String(existing.id)), duplicated: true };
+  }
+  const info = insertLibraryItem(db, 'character_libraries', { ...fields, created_at: now });
   log.info('Character added to material library (global)', { character_id: characterId, library_item_id: info.lastInsertRowid });
-  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)) };
+  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)), duplicated: false };
 }
 
 function updateCharacter(db, log, characterId, req) {
@@ -331,6 +377,7 @@ function batchGenerateCharacterImages(db, log, cfg, characterIds, modelName, sty
 function rowToItem(r) {
   return {
     id: r.id,
+    drama_id: r.drama_id ?? null,
     name: r.name,
     category: r.category,
     image_url: r.image_url,
@@ -338,6 +385,7 @@ function rowToItem(r) {
     description: r.description,
     tags: r.tags,
     source_type: r.source_type || 'generated',
+    source_id: r.source_id || null,
     created_at: r.created_at,
     updated_at: r.updated_at,
   };

--- a/backend-node/src/services/libraryDedup.js
+++ b/backend-node/src/services/libraryDedup.js
@@ -1,0 +1,145 @@
+const crypto = require('crypto');
+
+const KNOWN_TABLES = new Set([
+  'character_libraries',
+  'scene_libraries',
+  'prop_libraries',
+]);
+
+const columnCache = new WeakMap();
+
+function assertKnownTable(table) {
+  if (!KNOWN_TABLES.has(table)) {
+    throw new Error(`Unknown library table: ${table}`);
+  }
+}
+
+function hasColumn(db, table, column) {
+  assertKnownTable(table);
+  let tableCache = columnCache.get(db);
+  if (!tableCache) {
+    tableCache = new Map();
+    columnCache.set(db, tableCache);
+  }
+  const key = `${table}.${column}`;
+  if (tableCache.has(key)) return tableCache.get(key);
+  const columns = db.prepare(`PRAGMA table_info(${table})`).all();
+  const found = columns.some((row) => row.name === column);
+  tableCache.set(key, found);
+  return found;
+}
+
+function normalizeSourceId(id) {
+  if (id == null) return '';
+  return String(id).trim();
+}
+
+function normalizePathRef(value) {
+  let s = String(value || '').trim();
+  if (!s) return '';
+  s = s.replace(/\\/g, '/');
+  s = s.replace(/^\/?static\//i, '');
+  s = s.replace(/^\/+/, '');
+  return s;
+}
+
+function refKey(value) {
+  const s = String(value || '').trim();
+  if (!s) return '';
+  if (s.startsWith('data:')) {
+    return `data:${crypto.createHash('sha256').update(s).digest('hex')}`;
+  }
+  if (/^https?:\/\//i.test(s)) return `url:${s}`;
+  const pathRef = normalizePathRef(s);
+  return pathRef ? `path:${pathRef}` : '';
+}
+
+function identityKeys(row) {
+  const keys = new Set();
+  const sourceId = normalizeSourceId(row.source_id);
+  if (sourceId && row.source_type) keys.add(`source:${row.source_type}:${sourceId}`);
+  const imageKey = refKey(row.image_url);
+  const pathKey = refKey(row.local_path);
+  if (imageKey) keys.add(imageKey);
+  if (pathKey) keys.add(pathKey);
+  return keys;
+}
+
+function findExistingLibraryItem(db, table, { dramaId, sourceType, sourceId, imageUrl, localPath }) {
+  assertKnownTable(table);
+  const scopeSql = dramaId == null ? 'drama_id IS NULL' : 'drama_id = ?';
+  const params = dramaId == null ? [sourceType] : [sourceType, Number(dramaId)];
+  const rows = db.prepare(
+    `SELECT * FROM ${table} WHERE deleted_at IS NULL AND source_type = ? AND ${scopeSql} ORDER BY id ASC`
+  ).all(...params);
+
+  const wanted = identityKeys({
+    source_type: sourceType,
+    source_id: normalizeSourceId(sourceId),
+    image_url: imageUrl,
+    local_path: localPath,
+  });
+  if (wanted.size === 0) return null;
+
+  return rows.find((row) => {
+    const existing = identityKeys(row);
+    for (const key of wanted) {
+      if (existing.has(key)) return true;
+    }
+    return false;
+  }) || null;
+}
+
+function insertLibraryItem(db, table, fields) {
+  assertKnownTable(table);
+  const entries = Object.entries(fields)
+    .filter(([name, value]) => value !== undefined && (name !== 'source_id' || hasColumn(db, table, 'source_id')));
+  const names = entries.map(([name]) => name);
+  const placeholders = names.map(() => '?').join(', ');
+  const values = entries.map(([, value]) => value);
+  return db.prepare(
+    `INSERT INTO ${table} (${names.join(', ')}) VALUES (${placeholders})`
+  ).run(...values);
+}
+
+function updateLibraryItem(db, table, id, fields) {
+  assertKnownTable(table);
+  const entries = Object.entries(fields)
+    .filter(([name, value]) => value !== undefined && (name !== 'source_id' || hasColumn(db, table, 'source_id')));
+  if (entries.length === 0) return;
+  const assignments = entries.map(([name]) => `${name} = ?`);
+  const values = entries.map(([, value]) => value);
+  values.push(Number(id));
+  db.prepare(`UPDATE ${table} SET ${assignments.join(', ')} WHERE id = ?`).run(...values);
+}
+
+function parseSourceIds(value) {
+  if (Array.isArray(value)) {
+    return value.map(normalizeSourceId).filter(Boolean);
+  }
+  return String(value || '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean);
+}
+
+function appendSourceIdFilters(query, sql, params) {
+  if (query.source_id) {
+    sql += ' AND source_id = ?';
+    params.push(normalizeSourceId(query.source_id));
+  }
+  const sourceIds = parseSourceIds(query.source_ids);
+  if (sourceIds.length > 0) {
+    sql += ` AND source_id IN (${sourceIds.map(() => '?').join(', ')})`;
+    params.push(...sourceIds);
+  }
+  return sql;
+}
+
+module.exports = {
+  appendSourceIdFilters,
+  findExistingLibraryItem,
+  insertLibraryItem,
+  updateLibraryItem,
+  normalizeSourceId,
+};

--- a/backend-node/src/services/propLibraryService.js
+++ b/backend-node/src/services/propLibraryService.js
@@ -1,5 +1,11 @@
-// 道具库：仿 characterLibraryService
 const propService = require('./propService');
+const {
+  appendSourceIdFilters,
+  findExistingLibraryItem,
+  insertLibraryItem,
+  normalizeSourceId,
+  updateLibraryItem: updateExistingLibraryItem,
+} = require('./libraryDedup');
 
 function rowToItem(r) {
   return {
@@ -13,6 +19,7 @@ function rowToItem(r) {
     category: r.category,
     tags: r.tags,
     source_type: r.source_type || 'generated',
+    source_id: r.source_id || null,
     created_at: r.created_at,
     updated_at: r.updated_at,
   };
@@ -35,6 +42,7 @@ function listLibraryItems(db, query) {
     sql += ' AND source_type = ?';
     params.push(query.source_type);
   }
+  sql = appendSourceIdFilters(query, sql, params);
   if (query.keyword) {
     sql += ' AND (name LIKE ? OR description LIKE ? OR prompt LIKE ?)';
     const k = '%' + query.keyword + '%';
@@ -52,22 +60,20 @@ function listLibraryItems(db, query) {
 function createLibraryItem(db, log, req) {
   const now = new Date().toISOString();
   const sourceType = req.source_type || 'generated';
-  const info = db.prepare(
-    `INSERT INTO prop_libraries (drama_id, name, description, prompt, image_url, local_path, category, tags, source_type, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  ).run(
-    req.drama_id ?? null,
-    req.name || '',
-    req.description ?? null,
-    req.prompt ?? null,
-    req.image_url || '',
-    req.local_path ?? null,
-    req.category ?? null,
-    req.tags ?? null,
-    sourceType,
-    now,
-    now
-  );
+  const info = insertLibraryItem(db, 'prop_libraries', {
+    drama_id: req.drama_id ?? null,
+    name: req.name || '',
+    description: req.description ?? null,
+    prompt: req.prompt ?? null,
+    image_url: req.image_url || '',
+    local_path: req.local_path ?? null,
+    category: req.category ?? null,
+    tags: req.tags ?? null,
+    source_type: sourceType,
+    source_id: normalizeSourceId(req.source_id) || null,
+    created_at: now,
+    updated_at: now,
+  });
   log.info('Prop library item created', { item_id: info.lastInsertRowid });
   return getLibraryItem(db, String(info.lastInsertRowid));
 }
@@ -90,6 +96,7 @@ function updateLibraryItem(db, log, id, req) {
   if (req.category != null) { updates.push('category = ?'); params.push(req.category); }
   if (req.tags != null) { updates.push('tags = ?'); params.push(req.tags); }
   if (req.source_type != null) { updates.push('source_type = ?'); params.push(req.source_type); }
+  if (req.source_id != null) { updates.push('source_id = ?'); params.push(normalizeSourceId(req.source_id)); }
   if (updates.length === 0) return getLibraryItem(db, id);
   params.push(new Date().toISOString(), Number(id));
   db.prepare('UPDATE prop_libraries SET ' + updates.join(', ') + ', updated_at = ? WHERE id = ?').run(...params);
@@ -111,7 +118,20 @@ function resolveImageUrl(image_url, local_path) {
   return image_url || null;
 }
 
-// 加入本剧资源库（带 drama_id）
+function propLibraryFields(prop, dramaId, imageUrl, now) {
+  return {
+    drama_id: dramaId,
+    name: prop.name || '',
+    description: prop.description || null,
+    prompt: prop.prompt || null,
+    image_url: imageUrl,
+    local_path: prop.local_path || null,
+    source_type: 'prop',
+    source_id: normalizeSourceId(prop.id),
+    updated_at: now,
+  };
+}
+
 function addPropToLibrary(db, log, propId) {
   const prop = propService.getById(db, Number(propId));
   if (!prop) return { ok: false, error: 'prop not found' };
@@ -120,27 +140,46 @@ function addPropToLibrary(db, log, propId) {
   if (!prop.image_url && !prop.local_path) return { ok: false, error: '道具还没有形象图片' };
   const now = new Date().toISOString();
   const imageUrl = resolveImageUrl(prop.image_url, prop.local_path);
-  const info = db.prepare(
-    `INSERT INTO prop_libraries (drama_id, name, description, prompt, image_url, local_path, source_type, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, 'prop', ?, ?)`
-  ).run(prop.drama_id, prop.name || '', prop.description || null, prop.prompt || null, imageUrl, prop.local_path || null, now, now);
+  const fields = propLibraryFields(prop, prop.drama_id, imageUrl, now);
+  const existing = findExistingLibraryItem(db, 'prop_libraries', {
+    dramaId: prop.drama_id,
+    sourceType: 'prop',
+    sourceId: prop.id,
+    imageUrl,
+    localPath: prop.local_path,
+  });
+  if (existing) {
+    updateExistingLibraryItem(db, 'prop_libraries', existing.id, fields);
+    log.info('Prop library item reused', { prop_id: propId, drama_id: prop.drama_id, library_item_id: existing.id });
+    return { ok: true, item: getLibraryItem(db, String(existing.id)), duplicated: true };
+  }
+  const info = insertLibraryItem(db, 'prop_libraries', { ...fields, created_at: now });
   log.info('Prop added to drama library', { prop_id: propId, drama_id: prop.drama_id, library_item_id: info.lastInsertRowid });
-  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)) };
+  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)), duplicated: false };
 }
 
-// 加入全局素材库（drama_id = NULL）
 function addPropToMaterialLibrary(db, log, propId) {
   const prop = propService.getById(db, Number(propId));
   if (!prop) return { ok: false, error: 'prop not found' };
   if (!prop.image_url && !prop.local_path) return { ok: false, error: '道具还没有形象图片' };
   const now = new Date().toISOString();
   const imageUrl = resolveImageUrl(prop.image_url, prop.local_path);
-  const info = db.prepare(
-    `INSERT INTO prop_libraries (drama_id, name, description, prompt, image_url, local_path, source_type, created_at, updated_at)
-     VALUES (NULL, ?, ?, ?, ?, ?, 'prop', ?, ?)`
-  ).run(prop.name || '', prop.description || null, prop.prompt || null, imageUrl, prop.local_path || null, now, now);
+  const fields = propLibraryFields(prop, null, imageUrl, now);
+  const existing = findExistingLibraryItem(db, 'prop_libraries', {
+    dramaId: null,
+    sourceType: 'prop',
+    sourceId: prop.id,
+    imageUrl,
+    localPath: prop.local_path,
+  });
+  if (existing) {
+    updateExistingLibraryItem(db, 'prop_libraries', existing.id, fields);
+    log.info('Prop material library item reused', { prop_id: propId, library_item_id: existing.id });
+    return { ok: true, item: getLibraryItem(db, String(existing.id)), duplicated: true };
+  }
+  const info = insertLibraryItem(db, 'prop_libraries', { ...fields, created_at: now });
   log.info('Prop added to material library (global)', { prop_id: propId, library_item_id: info.lastInsertRowid });
-  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)) };
+  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)), duplicated: false };
 }
 
 module.exports = {

--- a/backend-node/src/services/sceneLibraryService.js
+++ b/backend-node/src/services/sceneLibraryService.js
@@ -1,5 +1,11 @@
-// 场景库：仿 characterLibraryService
 const sceneService = require('./sceneService');
+const {
+  appendSourceIdFilters,
+  findExistingLibraryItem,
+  insertLibraryItem,
+  normalizeSourceId,
+  updateLibraryItem: updateExistingLibraryItem,
+} = require('./libraryDedup');
 
 function rowToItem(r) {
   return {
@@ -14,6 +20,7 @@ function rowToItem(r) {
     category: r.category,
     tags: r.tags,
     source_type: r.source_type || 'generated',
+    source_id: r.source_id || null,
     created_at: r.created_at,
     updated_at: r.updated_at,
   };
@@ -36,6 +43,7 @@ function listLibraryItems(db, query) {
     sql += ' AND source_type = ?';
     params.push(query.source_type);
   }
+  sql = appendSourceIdFilters(query, sql, params);
   if (query.keyword) {
     sql += ' AND (location LIKE ? OR description LIKE ? OR prompt LIKE ?)';
     const k = '%' + query.keyword + '%';
@@ -53,23 +61,21 @@ function listLibraryItems(db, query) {
 function createLibraryItem(db, log, req) {
   const now = new Date().toISOString();
   const sourceType = req.source_type || 'generated';
-  const info = db.prepare(
-    `INSERT INTO scene_libraries (drama_id, location, time, prompt, description, image_url, local_path, category, tags, source_type, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  ).run(
-    req.drama_id ?? null,
-    req.location || '',
-    req.time ?? null,
-    req.prompt ?? null,
-    req.description ?? null,
-    req.image_url || '',
-    req.local_path ?? null,
-    req.category ?? null,
-    req.tags ?? null,
-    sourceType,
-    now,
-    now
-  );
+  const info = insertLibraryItem(db, 'scene_libraries', {
+    drama_id: req.drama_id ?? null,
+    location: req.location || '',
+    time: req.time ?? null,
+    prompt: req.prompt ?? null,
+    description: req.description ?? null,
+    image_url: req.image_url || '',
+    local_path: req.local_path ?? null,
+    category: req.category ?? null,
+    tags: req.tags ?? null,
+    source_type: sourceType,
+    source_id: normalizeSourceId(req.source_id) || null,
+    created_at: now,
+    updated_at: now,
+  });
   log.info('Scene library item created', { item_id: info.lastInsertRowid });
   return getLibraryItem(db, String(info.lastInsertRowid));
 }
@@ -93,6 +99,7 @@ function updateLibraryItem(db, log, id, req) {
   if (req.category != null) { updates.push('category = ?'); params.push(req.category); }
   if (req.tags != null) { updates.push('tags = ?'); params.push(req.tags); }
   if (req.source_type != null) { updates.push('source_type = ?'); params.push(req.source_type); }
+  if (req.source_id != null) { updates.push('source_id = ?'); params.push(normalizeSourceId(req.source_id)); }
   if (updates.length === 0) return getLibraryItem(db, id);
   params.push(new Date().toISOString(), Number(id));
   db.prepare('UPDATE scene_libraries SET ' + updates.join(', ') + ', updated_at = ? WHERE id = ?').run(...params);
@@ -114,7 +121,21 @@ function resolveImageUrl(image_url, local_path) {
   return image_url || null;
 }
 
-// 加入本剧资源库（带 drama_id）
+function sceneLibraryFields(scene, dramaId, imageUrl, now) {
+  return {
+    drama_id: dramaId,
+    location: scene.location || '',
+    time: scene.time || null,
+    prompt: scene.prompt || null,
+    description: scene.prompt || null,
+    image_url: imageUrl,
+    local_path: scene.local_path || null,
+    source_type: 'scene',
+    source_id: normalizeSourceId(scene.id),
+    updated_at: now,
+  };
+}
+
 function addSceneToLibrary(db, log, sceneId) {
   const scene = sceneService.getSceneById(db, Number(sceneId));
   if (!scene) return { ok: false, error: 'scene not found' };
@@ -123,27 +144,46 @@ function addSceneToLibrary(db, log, sceneId) {
   if (!scene.image_url && !scene.local_path) return { ok: false, error: '场景还没有形象图片' };
   const now = new Date().toISOString();
   const imageUrl = resolveImageUrl(scene.image_url, scene.local_path);
-  const info = db.prepare(
-    `INSERT INTO scene_libraries (drama_id, location, time, prompt, description, image_url, local_path, source_type, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, 'scene', ?, ?)`
-  ).run(scene.drama_id, scene.location || '', scene.time || null, scene.prompt || null, scene.prompt || null, imageUrl, scene.local_path || null, now, now);
+  const fields = sceneLibraryFields(scene, scene.drama_id, imageUrl, now);
+  const existing = findExistingLibraryItem(db, 'scene_libraries', {
+    dramaId: scene.drama_id,
+    sourceType: 'scene',
+    sourceId: scene.id,
+    imageUrl,
+    localPath: scene.local_path,
+  });
+  if (existing) {
+    updateExistingLibraryItem(db, 'scene_libraries', existing.id, fields);
+    log.info('Scene library item reused', { scene_id: sceneId, drama_id: scene.drama_id, library_item_id: existing.id });
+    return { ok: true, item: getLibraryItem(db, String(existing.id)), duplicated: true };
+  }
+  const info = insertLibraryItem(db, 'scene_libraries', { ...fields, created_at: now });
   log.info('Scene added to drama library', { scene_id: sceneId, drama_id: scene.drama_id, library_item_id: info.lastInsertRowid });
-  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)) };
+  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)), duplicated: false };
 }
 
-// 加入全局素材库（drama_id = NULL）
 function addSceneToMaterialLibrary(db, log, sceneId) {
   const scene = sceneService.getSceneById(db, Number(sceneId));
   if (!scene) return { ok: false, error: 'scene not found' };
   if (!scene.image_url && !scene.local_path) return { ok: false, error: '场景还没有形象图片' };
   const now = new Date().toISOString();
   const imageUrl = resolveImageUrl(scene.image_url, scene.local_path);
-  const info = db.prepare(
-    `INSERT INTO scene_libraries (drama_id, location, time, prompt, description, image_url, local_path, source_type, created_at, updated_at)
-     VALUES (NULL, ?, ?, ?, ?, ?, ?, 'scene', ?, ?)`
-  ).run(scene.location || '', scene.time || null, scene.prompt || null, scene.prompt || null, imageUrl, scene.local_path || null, now, now);
+  const fields = sceneLibraryFields(scene, null, imageUrl, now);
+  const existing = findExistingLibraryItem(db, 'scene_libraries', {
+    dramaId: null,
+    sourceType: 'scene',
+    sourceId: scene.id,
+    imageUrl,
+    localPath: scene.local_path,
+  });
+  if (existing) {
+    updateExistingLibraryItem(db, 'scene_libraries', existing.id, fields);
+    log.info('Scene material library item reused', { scene_id: sceneId, library_item_id: existing.id });
+    return { ok: true, item: getLibraryItem(db, String(existing.id)), duplicated: true };
+  }
+  const info = insertLibraryItem(db, 'scene_libraries', { ...fields, created_at: now });
   log.info('Scene added to material library (global)', { scene_id: sceneId, library_item_id: info.lastInsertRowid });
-  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)) };
+  return { ok: true, item: getLibraryItem(db, String(info.lastInsertRowid)), duplicated: false };
 }
 
 module.exports = {

--- a/backend-node/test/libraryDedup.test.js
+++ b/backend-node/test/libraryDedup.test.js
@@ -1,0 +1,184 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Database = require('better-sqlite3');
+
+const characterLibraryService = require('../src/services/characterLibraryService');
+const sceneLibraryService = require('../src/services/sceneLibraryService');
+const propLibraryService = require('../src/services/propLibraryService');
+
+const log = {
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function createDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE dramas (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT,
+      deleted_at TEXT
+    );
+
+    CREATE TABLE characters (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      drama_id INTEGER NOT NULL,
+      name TEXT NOT NULL DEFAULT '',
+      description TEXT,
+      appearance TEXT,
+      image_url TEXT,
+      local_path TEXT,
+      deleted_at TEXT
+    );
+
+    CREATE TABLE scenes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      drama_id INTEGER NOT NULL,
+      location TEXT,
+      time TEXT,
+      prompt TEXT,
+      image_url TEXT,
+      local_path TEXT,
+      deleted_at TEXT
+    );
+
+    CREATE TABLE props (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      drama_id INTEGER NOT NULL,
+      name TEXT NOT NULL DEFAULT '',
+      type TEXT,
+      description TEXT,
+      prompt TEXT,
+      image_url TEXT,
+      local_path TEXT,
+      deleted_at TEXT
+    );
+
+    CREATE TABLE character_libraries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      drama_id INTEGER,
+      name TEXT NOT NULL DEFAULT '',
+      category TEXT,
+      image_url TEXT,
+      local_path TEXT,
+      description TEXT,
+      tags TEXT,
+      source_type TEXT,
+      source_id TEXT,
+      created_at TEXT,
+      updated_at TEXT,
+      deleted_at TEXT
+    );
+
+    CREATE TABLE scene_libraries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      drama_id INTEGER,
+      location TEXT NOT NULL DEFAULT '',
+      time TEXT,
+      prompt TEXT,
+      description TEXT,
+      image_url TEXT,
+      local_path TEXT,
+      category TEXT,
+      tags TEXT,
+      source_type TEXT,
+      source_id TEXT,
+      created_at TEXT,
+      updated_at TEXT,
+      deleted_at TEXT
+    );
+
+    CREATE TABLE prop_libraries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      drama_id INTEGER,
+      name TEXT NOT NULL DEFAULT '',
+      description TEXT,
+      prompt TEXT,
+      image_url TEXT,
+      local_path TEXT,
+      category TEXT,
+      tags TEXT,
+      source_type TEXT,
+      source_id TEXT,
+      created_at TEXT,
+      updated_at TEXT,
+      deleted_at TEXT
+    );
+  `);
+  db.prepare('INSERT INTO dramas (id, title) VALUES (1, ?)').run('Test drama');
+  return db;
+}
+
+function countRows(db, table, where) {
+  return db.prepare(`SELECT COUNT(*) AS count FROM ${table} WHERE ${where}`).get().count;
+}
+
+test('adding the same character to drama and material libraries is idempotent', () => {
+  const db = createDb();
+  db.prepare(
+    'INSERT INTO characters (id, drama_id, name, description, image_url, local_path) VALUES (1, 1, ?, ?, ?, ?)'
+  ).run('Hero', 'original', '/static/projects/hero.png', 'projects/hero.png');
+
+  const firstDrama = characterLibraryService.addCharacterToLibrary(db, log, 1);
+  db.prepare('UPDATE characters SET name = ?, description = ? WHERE id = 1').run('Hero updated', 'updated');
+  const secondDrama = characterLibraryService.addCharacterToLibrary(db, log, 1);
+  const firstMaterial = characterLibraryService.addCharacterToMaterialLibrary(db, log, 1);
+  const secondMaterial = characterLibraryService.addCharacterToMaterialLibrary(db, log, 1);
+
+  assert.equal(firstDrama.item.id, secondDrama.item.id);
+  assert.equal(firstMaterial.item.id, secondMaterial.item.id);
+  assert.equal(countRows(db, 'character_libraries', 'drama_id = 1 AND deleted_at IS NULL'), 1);
+  assert.equal(countRows(db, 'character_libraries', 'drama_id IS NULL AND deleted_at IS NULL'), 1);
+  assert.equal(secondDrama.item.name, 'Hero updated');
+  assert.equal(
+    db.prepare('SELECT source_id FROM character_libraries WHERE id = ?').get(secondDrama.item.id).source_id,
+    '1'
+  );
+});
+
+test('adding the same scene to drama and material libraries is idempotent', () => {
+  const db = createDb();
+  db.prepare(
+    'INSERT INTO scenes (id, drama_id, location, time, prompt, image_url, local_path) VALUES (1, 1, ?, ?, ?, ?, ?)'
+  ).run('Village', 'day', 'quiet street', '/static/projects/village.png', 'projects/village.png');
+
+  const firstDrama = sceneLibraryService.addSceneToLibrary(db, log, 1);
+  db.prepare('UPDATE scenes SET location = ?, prompt = ? WHERE id = 1').run('Village updated', 'busy street');
+  const secondDrama = sceneLibraryService.addSceneToLibrary(db, log, 1);
+  const firstMaterial = sceneLibraryService.addSceneToMaterialLibrary(db, log, 1);
+  const secondMaterial = sceneLibraryService.addSceneToMaterialLibrary(db, log, 1);
+
+  assert.equal(firstDrama.item.id, secondDrama.item.id);
+  assert.equal(firstMaterial.item.id, secondMaterial.item.id);
+  assert.equal(countRows(db, 'scene_libraries', 'drama_id = 1 AND deleted_at IS NULL'), 1);
+  assert.equal(countRows(db, 'scene_libraries', 'drama_id IS NULL AND deleted_at IS NULL'), 1);
+  assert.equal(secondDrama.item.location, 'Village updated');
+  assert.equal(
+    db.prepare('SELECT source_id FROM scene_libraries WHERE id = ?').get(secondDrama.item.id).source_id,
+    '1'
+  );
+});
+
+test('adding the same prop to drama and material libraries is idempotent', () => {
+  const db = createDb();
+  db.prepare(
+    'INSERT INTO props (id, drama_id, name, description, prompt, image_url, local_path) VALUES (1, 1, ?, ?, ?, ?, ?)'
+  ).run('Sword', 'old blade', 'silver sword', '/static/projects/sword.png', 'projects/sword.png');
+
+  const firstDrama = propLibraryService.addPropToLibrary(db, log, 1);
+  db.prepare('UPDATE props SET name = ?, description = ? WHERE id = 1').run('Sword updated', 'polished blade');
+  const secondDrama = propLibraryService.addPropToLibrary(db, log, 1);
+  const firstMaterial = propLibraryService.addPropToMaterialLibrary(db, log, 1);
+  const secondMaterial = propLibraryService.addPropToMaterialLibrary(db, log, 1);
+
+  assert.equal(firstDrama.item.id, secondDrama.item.id);
+  assert.equal(firstMaterial.item.id, secondMaterial.item.id);
+  assert.equal(countRows(db, 'prop_libraries', 'drama_id = 1 AND deleted_at IS NULL'), 1);
+  assert.equal(countRows(db, 'prop_libraries', 'drama_id IS NULL AND deleted_at IS NULL'), 1);
+  assert.equal(secondDrama.item.name, 'Sword updated');
+  assert.equal(
+    db.prepare('SELECT source_id FROM prop_libraries WHERE id = ?').get(secondDrama.item.id).source_id,
+    '1'
+  );
+});

--- a/frontweb/src/composables/filmCreate/libraryMembership.js
+++ b/frontweb/src/composables/filmCreate/libraryMembership.js
@@ -1,0 +1,76 @@
+import { ref } from 'vue'
+
+export function createLibraryMembershipState() {
+  return {
+    dramaSourceIds: ref(new Set()),
+    materialSourceIds: ref(new Set()),
+  }
+}
+
+function assetSourceId(asset) {
+  if (asset?.id == null) return ''
+  return String(asset.id).trim()
+}
+
+function itemSourceId(item) {
+  if (item?.source_id == null) return ''
+  return String(item.source_id).trim()
+}
+
+function chunkArray(items, size) {
+  const chunks = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}
+
+async function fetchSourceIds(api, params, ids) {
+  const out = new Set()
+  for (const chunk of chunkArray(ids, 80)) {
+    const res = await api.list({
+      ...params,
+      source_ids: chunk.join(','),
+      page_size: chunk.length || 1,
+    })
+    for (const item of res?.items || []) {
+      const id = itemSourceId(item)
+      if (id) out.add(id)
+    }
+  }
+  return out
+}
+
+export async function loadLibraryMembership({ api, sourceType, assets, dramaId, dramaSourceIds, materialSourceIds }) {
+  const ids = [...new Set((assets || []).map(assetSourceId).filter(Boolean))]
+  if (ids.length === 0) {
+    dramaSourceIds.value = new Set()
+    materialSourceIds.value = new Set()
+    return
+  }
+  try {
+    const [dramaIds, materialIds] = await Promise.all([
+      dramaId
+        ? fetchSourceIds(api, { drama_id: dramaId, source_type: sourceType }, ids)
+        : Promise.resolve(new Set()),
+      fetchSourceIds(api, { global: 1, source_type: sourceType }, ids),
+    ])
+    dramaSourceIds.value = dramaIds
+    materialSourceIds.value = materialIds
+  } catch (err) {
+    console.warn('[libraryMembership] load failed:', err?.message || err)
+    dramaSourceIds.value = new Set()
+    materialSourceIds.value = new Set()
+  }
+}
+
+export function hasAssetInLibrary(sourceIdsRef, asset) {
+  const id = assetSourceId(asset)
+  return !!id && sourceIdsRef.value.has(id)
+}
+
+export function markAssetInLibrary(sourceIdsRef, asset) {
+  const id = assetSourceId(asset)
+  if (!id) return
+  sourceIdsRef.value = new Set([...sourceIdsRef.value, id])
+}

--- a/frontweb/src/composables/filmCreate/useCharacters.js
+++ b/frontweb/src/composables/filmCreate/useCharacters.js
@@ -5,6 +5,7 @@ import { characterLibraryAPI } from '@/api/characterLibrary'
 import { dramaAPI } from '@/api/drama'
 import { generationAPI } from '@/api/generation'
 import { uploadAPI } from '@/api/upload'
+import { createLibraryMembershipState, hasAssetInLibrary, loadLibraryMembership, markAssetInLibrary } from './libraryMembership'
 
 /**
  * 角色管理 Composable
@@ -64,6 +65,7 @@ export function useCharacters(deps) {
   const sd2CertifyingId = ref(null)
   const showCharSd2Cert = ref(false)
   const charSd2CertPayload = ref(null)
+  const charMembership = createLibraryMembershipState()
   let charLibraryKeywordTimer = null
 
   // ── 常量 ──────────────────────────────────────────────
@@ -412,6 +414,7 @@ export function useCharacters(deps) {
     addingCharToLibraryId.value = char.id
     try {
       await characterAPI.addToLibrary(char.id, {})
+      markAssetInLibrary(charMembership.dramaSourceIds, char)
       ElMessage.success('已加入本剧角色库')
       if (showCharLibrary.value) loadCharLibraryList()
     } catch (e) {
@@ -426,6 +429,7 @@ export function useCharacters(deps) {
     addingCharToMaterialId.value = char.id
     try {
       await characterAPI.addToMaterialLibrary(char.id)
+      markAssetInLibrary(charMembership.materialSourceIds, char)
       ElMessage.success('已加入全局素材库')
     } catch (e) {
       ElMessage.error(e.message || '加入失败')
@@ -487,6 +491,25 @@ export function useCharacters(deps) {
   function openCharSd2CertDialog(char) {
     charSd2CertPayload.value = char.seedance2_asset ? { ...char.seedance2_asset } : null
     showCharSd2Cert.value = true
+  }
+
+  async function loadCharLibraryMembership() {
+    await loadLibraryMembership({
+      api: characterLibraryAPI,
+      sourceType: 'character',
+      assets: store.characters || [],
+      dramaId: dramaId.value,
+      dramaSourceIds: charMembership.dramaSourceIds,
+      materialSourceIds: charMembership.materialSourceIds,
+    })
+  }
+
+  function isCharInLibrary(char) {
+    return hasAssetInLibrary(charMembership.dramaSourceIds, char)
+  }
+
+  function isCharInMaterialLibrary(char) {
+    return hasAssetInLibrary(charMembership.materialSourceIds, char)
   }
 
   async function onAddCharFromLibrary(item) {
@@ -616,6 +639,9 @@ export function useCharacters(deps) {
     onCloseCharDialog,
     onDeleteCharacter,
     onGenerateCharacterImage,
+    loadCharLibraryMembership,
+    isCharInLibrary,
+    isCharInMaterialLibrary,
     loadCharLibraryList,
     debouncedLoadCharLibrary,
     openEditCharLibrary,

--- a/frontweb/src/composables/filmCreate/useProps.js
+++ b/frontweb/src/composables/filmCreate/useProps.js
@@ -3,6 +3,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import { propAPI } from '@/api/props'
 import { propLibraryAPI } from '@/api/propLibrary'
 import { uploadAPI } from '@/api/upload'
+import { createLibraryMembershipState, hasAssetInLibrary, loadLibraryMembership, markAssetInLibrary } from './libraryMembership'
 
 /**
  * 道具管理 Composable
@@ -67,6 +68,7 @@ export function useProps(deps) {
   const addingPropToLibraryId = ref(null)
   const addingPropToMaterialId = ref(null)
   const addingPropFromLibraryId = ref(null)
+  const propMembership = createLibraryMembershipState()
   let propLibraryKeywordTimer = null
 
   // ── 函数 ──────────────────────────────────────────────
@@ -379,6 +381,7 @@ export function useProps(deps) {
     addingPropToLibraryId.value = prop.id
     try {
       await propAPI.addToLibrary(prop.id, {})
+      markAssetInLibrary(propMembership.dramaSourceIds, prop)
       ElMessage.success('已加入本剧道具库')
       if (showPropLibrary.value) loadPropLibraryList()
     } catch (e) {
@@ -393,12 +396,32 @@ export function useProps(deps) {
     addingPropToMaterialId.value = prop.id
     try {
       await propAPI.addToMaterialLibrary(prop.id)
+      markAssetInLibrary(propMembership.materialSourceIds, prop)
       ElMessage.success('已加入全局素材库')
     } catch (e) {
       ElMessage.error(e.message || '加入失败')
     } finally {
       addingPropToMaterialId.value = null
     }
+  }
+
+  async function loadPropLibraryMembership() {
+    await loadLibraryMembership({
+      api: propLibraryAPI,
+      sourceType: 'prop',
+      assets: store.props || [],
+      dramaId: dramaId.value,
+      dramaSourceIds: propMembership.dramaSourceIds,
+      materialSourceIds: propMembership.materialSourceIds,
+    })
+  }
+
+  function isPropInLibrary(prop) {
+    return hasAssetInLibrary(propMembership.dramaSourceIds, prop)
+  }
+
+  function isPropInMaterialLibrary(prop) {
+    return hasAssetInLibrary(propMembership.materialSourceIds, prop)
   }
 
   async function onAddPropFromLibrary(item) {
@@ -502,6 +525,9 @@ export function useProps(deps) {
     onClosePropDialog,
     onDeleteProp,
     onGeneratePropImage,
+    loadPropLibraryMembership,
+    isPropInLibrary,
+    isPropInMaterialLibrary,
     loadPropLibraryList,
     debouncedLoadPropLibrary,
     openEditPropLibrary,

--- a/frontweb/src/composables/filmCreate/useScenes.js
+++ b/frontweb/src/composables/filmCreate/useScenes.js
@@ -3,6 +3,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import { sceneAPI } from '@/api/scenes'
 import { sceneLibraryAPI } from '@/api/sceneLibrary'
 import { uploadAPI } from '@/api/upload'
+import { createLibraryMembershipState, hasAssetInLibrary, loadLibraryMembership, markAssetInLibrary } from './libraryMembership'
 
 /**
  * 场景管理 Composable
@@ -60,6 +61,7 @@ export function useScenes(deps) {
   const addingSceneToLibraryId = ref(null)
   const addingSceneToMaterialId = ref(null)
   const addingSceneFromLibraryId = ref(null)
+  const sceneMembership = createLibraryMembershipState()
   let sceneLibraryKeywordTimer = null
 
   // ── 函数 ──────────────────────────────────────────────
@@ -382,6 +384,7 @@ export function useScenes(deps) {
     addingSceneToLibraryId.value = scene.id
     try {
       await sceneAPI.addToLibrary(scene.id, {})
+      markAssetInLibrary(sceneMembership.dramaSourceIds, scene)
       ElMessage.success('已加入本剧场景库')
       if (showSceneLibrary.value) loadSceneLibraryList()
     } catch (e) {
@@ -396,12 +399,32 @@ export function useScenes(deps) {
     addingSceneToMaterialId.value = scene.id
     try {
       await sceneAPI.addToMaterialLibrary(scene.id)
+      markAssetInLibrary(sceneMembership.materialSourceIds, scene)
       ElMessage.success('已加入全局素材库')
     } catch (e) {
       ElMessage.error(e.message || '加入失败')
     } finally {
       addingSceneToMaterialId.value = null
     }
+  }
+
+  async function loadSceneLibraryMembership() {
+    await loadLibraryMembership({
+      api: sceneLibraryAPI,
+      sourceType: 'scene',
+      assets: store.scenes || [],
+      dramaId: dramaId.value,
+      dramaSourceIds: sceneMembership.dramaSourceIds,
+      materialSourceIds: sceneMembership.materialSourceIds,
+    })
+  }
+
+  function isSceneInLibrary(scene) {
+    return hasAssetInLibrary(sceneMembership.dramaSourceIds, scene)
+  }
+
+  function isSceneInMaterialLibrary(scene) {
+    return hasAssetInLibrary(sceneMembership.materialSourceIds, scene)
   }
 
   async function onAddSceneFromLibrary(item) {
@@ -477,6 +500,9 @@ export function useScenes(deps) {
     onCloseSceneDialog,
     onDeleteScene,
     onGenerateSceneImage,
+    loadSceneLibraryMembership,
+    isSceneInLibrary,
+    isSceneInMaterialLibrary,
     loadSceneLibraryList,
     debouncedLoadSceneLibrary,
     openEditSceneLibrary,

--- a/frontweb/src/views/FilmCreate.vue
+++ b/frontweb/src/views/FilmCreate.vue
@@ -404,11 +404,11 @@
                     <div class="asset-desc-full">{{ char.appearance || char.description || '暂无描述' }}</div>
                     <div class="asset-btns">
                       <el-button size="small" @click="editCharacter(char)">编辑</el-button>
-                      <el-button size="small" :loading="addingCharToLibraryId === char.id" :disabled="!hasAssetImage(char)" @click="onAddCharacterToLibrary(char)">
-                        加入本剧库
+                      <el-button size="small" :type="isCharInLibrary(char) ? 'success' : ''" :loading="addingCharToLibraryId === char.id" :disabled="!hasAssetImage(char) || isCharInLibrary(char)" @click="onAddCharacterToLibrary(char)">
+                        {{ isCharInLibrary(char) ? '已加入本剧库' : '加入本剧库' }}
                       </el-button>
-                      <el-button size="small" :loading="addingCharToMaterialId === char.id" :disabled="!hasAssetImage(char)" @click="onAddCharacterToMaterialLibrary(char)">
-                        加入素材库
+                      <el-button size="small" :type="isCharInMaterialLibrary(char) ? 'success' : ''" :loading="addingCharToMaterialId === char.id" :disabled="!hasAssetImage(char) || isCharInMaterialLibrary(char)" @click="onAddCharacterToMaterialLibrary(char)">
+                        {{ isCharInMaterialLibrary(char) ? '已加入素材库' : '加入素材库' }}
                       </el-button>
                       <span v-if="char.seedance2_asset?.status !== 'active'" class="sd2-cert-btn-wrap">
                         <el-button
@@ -544,11 +544,11 @@
                     <div class="asset-desc-full">{{ prop.description || prop.prompt || '暂无描述' }}</div>
                     <div class="asset-btns">
                       <el-button size="small" @click="editProp(prop)">编辑</el-button>
-                      <el-button size="small" :loading="addingPropToLibraryId === prop.id" :disabled="!hasAssetImage(prop)" @click="onAddPropToLibrary(prop)">
-                        加入本剧库
+                      <el-button size="small" :type="isPropInLibrary(prop) ? 'success' : ''" :loading="addingPropToLibraryId === prop.id" :disabled="!hasAssetImage(prop) || isPropInLibrary(prop)" @click="onAddPropToLibrary(prop)">
+                        {{ isPropInLibrary(prop) ? '已加入本剧库' : '加入本剧库' }}
                       </el-button>
-                      <el-button size="small" :loading="addingPropToMaterialId === prop.id" :disabled="!hasAssetImage(prop)" @click="onAddPropToMaterialLibrary(prop)">
-                        加入素材库
+                      <el-button size="small" :type="isPropInMaterialLibrary(prop) ? 'success' : ''" :loading="addingPropToMaterialId === prop.id" :disabled="!hasAssetImage(prop) || isPropInMaterialLibrary(prop)" @click="onAddPropToMaterialLibrary(prop)">
+                        {{ isPropInMaterialLibrary(prop) ? '已加入素材库' : '加入素材库' }}
                       </el-button>
                     </div>
                   </div>
@@ -617,11 +617,11 @@
                     <div class="asset-desc-full">{{ scene.description || scene.prompt || scene.time || '暂无描述' }}</div>
                     <div class="asset-btns">
                       <el-button size="small" @click="editScene(scene)">编辑</el-button>
-                      <el-button size="small" :loading="addingSceneToLibraryId === scene.id" :disabled="!hasAssetImage(scene)" @click="onAddSceneToLibrary(scene)">
-                        加入本剧库
+                      <el-button size="small" :type="isSceneInLibrary(scene) ? 'success' : ''" :loading="addingSceneToLibraryId === scene.id" :disabled="!hasAssetImage(scene) || isSceneInLibrary(scene)" @click="onAddSceneToLibrary(scene)">
+                        {{ isSceneInLibrary(scene) ? '已加入本剧库' : '加入本剧库' }}
                       </el-button>
-                      <el-button size="small" :loading="addingSceneToMaterialId === scene.id" :disabled="!hasAssetImage(scene)" @click="onAddSceneToMaterialLibrary(scene)">
-                        加入素材库
+                      <el-button size="small" :type="isSceneInMaterialLibrary(scene) ? 'success' : ''" :loading="addingSceneToMaterialId === scene.id" :disabled="!hasAssetImage(scene) || isSceneInMaterialLibrary(scene)" @click="onAddSceneToMaterialLibrary(scene)">
+                        {{ isSceneInMaterialLibrary(scene) ? '已加入素材库' : '加入素材库' }}
                       </el-button>
                     </div>
                     <div v-if="getSceneAffectedStoryboards(scene.id).length" class="asset-storyboard-link">
@@ -2428,6 +2428,7 @@ const {
   charRoleLabel, onGenerateCharacters, openAddCharacter, stopCharacterPromptPoll, editCharacter,
   saveCharRefImageIfAny, submitEditCharacter, doGenerateCharacterPrompt, doExtractCharFromImage,
   extractIdentityAnchors, clearCharRefImage, onCloseCharDialog, onDeleteCharacter, onGenerateCharacterImage,
+  loadCharLibraryMembership, isCharInLibrary, isCharInMaterialLibrary,
   loadCharLibraryList, debouncedLoadCharLibrary, openEditCharLibrary, submitEditCharLibrary,
   onDeleteCharLibrary, onAddCharacterToLibrary, onAddCharacterToMaterialLibrary, onSd2CertifyCharacter,
   onSd2CertifyRefresh, openCharSd2CertDialog, onAddCharFromLibrary,
@@ -2446,6 +2447,7 @@ const {
   onExtractProps, stopPropPromptPoll, editProp, doGeneratePropPrompt, savePropRefImageIfAny,
   clearPropRefImage, doExtractPropFromImage, submitEditProp, submitAddProp,
   onClosePropDialog, onDeleteProp, onGeneratePropImage,
+  loadPropLibraryMembership, isPropInLibrary, isPropInMaterialLibrary,
   loadPropLibraryList, debouncedLoadPropLibrary, openEditPropLibrary, submitEditPropLibrary,
   onDeletePropLibrary, onAddPropToLibrary, onAddPropToMaterialLibrary, onAddPropFromLibrary,
   doExtractFromRef2,
@@ -2463,6 +2465,7 @@ const {
   onExtractScenes, openAddScene, stopScenePromptPoll, editScene, doGenerateScenePrompt,
   saveSceneRefImageIfAny, clearSceneRefImage, doExtractSceneFromImage, submitEditScene,
   onCloseSceneDialog, onDeleteScene, onGenerateSceneImage,
+  loadSceneLibraryMembership, isSceneInLibrary, isSceneInMaterialLibrary,
   loadSceneLibraryList, debouncedLoadSceneLibrary, openEditSceneLibrary, submitEditSceneLibrary,
   onDeleteSceneLibrary, onAddSceneToLibrary, onAddSceneToMaterialLibrary, onAddSceneFromLibrary,
 } = useScenes({ store, dramaId, currentEpisodeId, getSelectedStyle, getAssetImageModel, scriptLanguage, loadDrama, pollTask, pollUntilResourceHasImage, hasAssetImage, dramaAPI })
@@ -3408,6 +3411,14 @@ function onEpisodeSelect(epId) {
   loadStoryboardMedia()
 }
 
+async function refreshLibraryMembership() {
+  await Promise.allSettled([
+    loadCharLibraryMembership(),
+    loadPropLibraryMembership(),
+    loadSceneLibraryMembership(),
+  ])
+}
+
 async function loadDrama() {
   if (!store.dramaId) return
   try {
@@ -3442,6 +3453,7 @@ async function loadDrama() {
       scriptTitle.value = ''
       selectedEpisodeId.value = null
     }
+    await refreshLibraryMembership()
     syncStoryboardStateFromEpisode(ep)
     await loadStoryboardMedia()
   } catch (e) {


### PR DESCRIPTION
  PR 标题

  修复素材库和本剧库重复加入问题

  PR 内容

  ## 改动说明 / Description

  修复影视创作页中角色、场景、道具重复加入「本剧库」和「素材库」的问题。

  此前同一个资产可以反复点击加入，后端会持续创建重复记录，前端也不会识别资产是否已经入库。本次改动增加后端去重逻辑，并在前端显示已加入状态，避免重复添加。

  主要改动：

  - 后端为角色库、场景库、道具库增加来源资产识别和去重逻辑。
  - 新增 `source_id` / `drama_id` 字段及数据库迁移，兼容历史数据。
  - 资产库接口支持按 `source_ids` 查询，供前端批量判断入库状态。
  - 前端在影视创作页加载角色、场景、道具的入库状态。
  - 已加入的资产按钮会禁用，并显示「已加入本剧库」或「已加入素材库」。
  - 补充后端去重测试，覆盖角色、场景、道具的本剧库和素材库场景。

  ## 改动类型 / Type of Change

  - [x] Bug 修复 / Bug fix
  - [ ] ✨ 新功能 / New feature
  - [ ] ♻️ 代码重构 / Refactoring (no functional change)
  - [ ] 文档更新 / Documentation update
  - [x] UI/样式调整 / UI / style change
  - [ ] ⚡ 性能优化 / Performance improvement
  - [ ] 构建/配置变更 / Build / config change

  ## 关联 Issue / Related Issue

  暂无关联 Issue。

  ## 测试说明 / Testing

  已完成以下验证：

  - 后端去重测试通过：`node --test test\libraryDedup.test.js`
  - 数据库迁移在内存数据库中执行通过
  - 前端构建通过：`npm run build`
  - 本地前后端启动验证通过：
    - 后端健康检查：`http://localhost:5679/health` 返回 200
    - 前端页面：`http://localhost:3013` 返回 200

  - [x] 本地开发模式测试通过 / Tested in dev mode
  - [ ] 打包 exe 测试通过 / Tested with packaged exe
  - [x] 相关功能无明显回归 / No obvious regression

  ## 截图 / Screenshots
<img width="2329" height="755" alt="image" src="https://github.com/user-attachments/assets/6b7b534a-1dd1-46ce-99ac-2c44341f9819" />

  本次改动涉及按钮状态显示：

  - 未加入时：显示「加入本剧库」「加入素材库」
  - 已加入后：按钮禁用，并显示「已加入本剧库」「已加入素材库」

  如维护者需要，可在本地测试页补充前后对比截图。

  ## 检查清单 / Checklist

  - [x] 代码符合项目现有风格（纯 JavaScript，无 TypeScript）/ Code follows project style (vanilla JS)
  - [x] 没有引入不必要的依赖 / No unnecessary new dependencies
  - [x] 如有必要，已更新相关文档 / Documentation updated if needed