### PR TITLE
[codex] Fix episode selection after script generation

### DIFF
--- a/frontweb/src/composables/useStoryGeneration.js
+++ b/frontweb/src/composables/useStoryGeneration.js
@@ -35,6 +35,8 @@ export async function runGenerateStoryFromPremise({
     return { ok: false }
   }
 
+  const preferredEpisodeNumber = store.currentEpisode?.episode_number ?? savedCurrentEpisodeNumber?.value ?? 1
+
   storyGenerating.value = true
   try {
     const res = await generationAPI.generateStory({
@@ -77,7 +79,7 @@ export async function runGenerateStoryFromPremise({
         title: ep.title || `第${ep.episode ?? i + 1}集`,
         script_content: ep.content || '',
       }))
-      savedCurrentEpisodeNumber.value = 1
+      savedCurrentEpisodeNumber.value = preferredEpisodeNumber
       await dramaAPI.saveEpisodes(dramaId, epPayload)
 
       await dramaAPI.saveOutline(dramaId, {
@@ -94,10 +96,12 @@ export async function runGenerateStoryFromPremise({
       if (!skipPostLoad) {
         await loadDrama()
 
-        const firstEp = (store.drama?.episodes || [])[0]
-        if (firstEp) {
-          selectedEpisodeId.value = firstEp.id
-          onEpisodeSelect(firstEp.id)
+        const episodesAfterSave = store.drama?.episodes || []
+        const preferredEp = episodesAfterSave.find((ep) => Number(ep.episode_number) === Number(preferredEpisodeNumber))
+          || episodesAfterSave[0]
+        if (preferredEp) {
+          selectedEpisodeId.value = preferredEp.id
+          onEpisodeSelect(preferredEp.id)
         }
       }
 

--- a/frontweb/src/composables/useStoryGeneration.js
+++ b/frontweb/src/composables/useStoryGeneration.js
@@ -107,7 +107,7 @@ export async function runGenerateStoryFromPremise({
 
       const n = episodes.length
       if (!skipPostLoad) {
-        ElMessage.success(n > 1 ? `剧本已生成，共 ${n} 集，已默认选中第1集` : '剧本已生成并已保存')
+        ElMessage.success(n > 1 ? `剧本已生成，共 ${n} 集，已保留当前集选择` : '剧本已生成并已保存')
       } else {
         ElMessage.success(n > 1 ? `剧本已生成，共 ${n} 集` : '剧本已生成并已保存')
       }

--- a/frontweb/src/views/FilmCreate.vue
+++ b/frontweb/src/views/FilmCreate.vue
@@ -5148,6 +5148,11 @@ async function onAddEpisode() {
     await dramaAPI.saveEpisodes(store.dramaId, updated)
     savedCurrentEpisodeNumber.value = nextNum
     await loadDrama()
+    const newEpisode = (store.drama?.episodes || []).find((e) => Number(e.episode_number) === Number(nextNum))
+    if (newEpisode) {
+      selectedEpisodeId.value = newEpisode.id
+      onEpisodeSelect(newEpisode.id)
+    }
     ElMessage.success('已添加第' + nextNum + '集')
   } catch (e) {
     ElMessage.error(e.message || '添加失败')


### PR DESCRIPTION
## Summary

Fixes episode selection state in the film creation page when users add a new episode or generate scripts from the story prompt.

## Issue

When a user adds a new episode and then works from the script generation panel, the UI can jump back to the first or previous episode. This makes it look like the newly added episode did not receive the generated or saved script.

## Root cause

The add-episode path saved the new episode and reloaded the drama, but did not explicitly select the newly created episode after the reload. The story-generation path also reset savedCurrentEpisodeNumber to 1 and then selected the first episode after generation, regardless of which episode the user was editing.

## Fix

- After adding an episode, find the new episode by episode_number and select it explicitly.
- During story generation, preserve the current episode number as the preferred target and reselect that episode after saving/reloading.

## Validation

- Ran `npm run build` in `frontweb` successfully.